### PR TITLE
Change la contrainte de suppression sur les unités de matériel dans les events

### DIFF
--- a/server/src/database/migrations/20201224140829_changes_material_units_constraint.php
+++ b/server/src/database/migrations/20201224140829_changes_material_units_constraint.php
@@ -1,0 +1,31 @@
+<?php
+use Phinx\Migration\AbstractMigration;
+
+class ChangesMaterialUnitsConstraint extends AbstractMigration
+{
+    public function up()
+    {
+        $table = $this->table('event_material_units');
+        $table->dropForeignKey('material_unit_id')->save();
+        $table
+            ->addForeignKey('material_unit_id', 'material_units', 'id', [
+                'delete' => 'CASCADE',
+                'update' => 'NO_ACTION',
+                'constraint' => 'fk_event_material_unit_material_unit',
+            ])
+            ->save();
+    }
+
+    public function down()
+    {
+        $table = $this->table('event_material_units');
+        $table->dropForeignKey('material_unit_id')->save();
+        $table
+            ->addForeignKey('material_unit_id', 'material_units', 'id', [
+                'delete' => 'RESTRICT',
+                'update' => 'NO_ACTION',
+                'constraint' => 'fk_event_material_unit_material_unit',
+            ])
+            ->save();
+    }
+}


### PR DESCRIPTION
Ceci sera rollback lorsque l'on prendra en charge le switch-back Gestion unitaire => Gestion non-unitaire dans l'édition d'un matériel (avec alerte ou blocage + explications dans l'UI).

_Un ticket a été ouvert dans le repo. approprié pour cela._