### PR TITLE
Améliore (encore) la validation

### DIFF
--- a/server/src/App/Validation/Rules/Callback.php
+++ b/server/src/App/Validation/Rules/Callback.php
@@ -2,8 +2,10 @@
 
 namespace Robert2\API\Validation\Rules;
 
-use Respect\Validation\Rules\AbstractRule;
 use Respect\Validation\Exceptions\ComponentException;
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Rules\AbstractRule;
+use Respect\Validation\Validator;
 
 class Callback extends AbstractRule
 {
@@ -23,7 +25,32 @@ class Callback extends AbstractRule
         $this->arguments = $arguments;
     }
 
+    public function assert($input)
+    {
+        $result = $this->_validate($input);
+        if ($result instanceof NestedValidationException) {
+            throw $result;
+        }
+
+        if ($result) {
+            return true;
+        }
+
+        throw $this->reportError($input);
+    }
+
     public function validate($input)
+    {
+        return $this->_validate($input) === true;
+    }
+
+    // ------------------------------------------------------
+    // -
+    // -    Internal methods
+    // -
+    // ------------------------------------------------------
+
+    protected function _validate($input)
     {
         $params = $this->arguments;
         array_unshift($params, $input);
@@ -31,6 +58,16 @@ class Callback extends AbstractRule
         $result = call_user_func_array($this->callback, $params);
         if (is_bool($result)) {
             return $result;
+        }
+
+        if ($result instanceof Validator) {
+            try {
+                $result->setName($this->name)->assert($input);
+            } catch (NestedValidationException $e) {
+                $this->setTemplate($e->getFullMessage());
+                return $e;
+            }
+            return true;
         }
 
         $this->setTemplate($result);

--- a/server/tests/endpoints/BillsTest.php
+++ b/server/tests/endpoints/BillsTest.php
@@ -1,9 +1,6 @@
 <?php
 namespace Robert2\Tests;
 
-use Robert2\API\I18n\I18n;
-use Robert2\API\Config\Config;
-
 final class BillsTest extends ApiTestCase
 {
     public function testGetBill()
@@ -63,7 +60,7 @@ final class BillsTest extends ApiTestCase
     {
         $this->client->post('/api/events/2/bill');
         $this->assertStatusCode(SUCCESS_CREATED);
-        $newBillNumber = sprintf('%s-00002', date('Y'));
+        $newBillNumber = sprintf('%s-00001', date('Y'));
         $this->assertResponseData([
             'id'             => 2,
             'number'         => $newBillNumber,
@@ -114,7 +111,7 @@ final class BillsTest extends ApiTestCase
     {
         $this->client->post('/api/events/2/bill', ['discountRate' => 50.0]);
         $this->assertStatusCode(SUCCESS_CREATED);
-        $newBillNumber = sprintf('%s-00002', date('Y'));
+        $newBillNumber = sprintf('%s-00001', date('Y'));
         $this->assertResponseData([
             'id'             => 2,
             'number'         => $newBillNumber,

--- a/server/tests/models/BillTest.php
+++ b/server/tests/models/BillTest.php
@@ -5,8 +5,6 @@ namespace Robert2\Tests;
 
 use Robert2\API\Models;
 use Robert2\API\Errors;
-use Robert2\API\I18n\I18n;
-use Robert2\API\Config\Config;
 
 final class BillTest extends ModelTestCase
 {
@@ -159,7 +157,7 @@ final class BillTest extends ModelTestCase
     public function testCreateFromEvent()
     {
         $result = $this->model->createFromEvent(2, 1, 25.9542);
-        $newBillNumber = sprintf('%s-00002', date('Y'));
+        $newBillNumber = sprintf('%s-00001', date('Y'));
         $expected = [
             'id'             => 2,
             'number'         => $newBillNumber,
@@ -231,6 +229,6 @@ final class BillTest extends ModelTestCase
     public function testGetLastBillNumber()
     {
         $result = $this->model->getLastBillNumber();
-        $this->assertEquals(1, $result);
+        $this->assertEquals(0, $result);
     }
 }


### PR DESCRIPTION
Cette PR ajoute la possibilité de retourner directement des instances de `Respect\Validation\Validator` depuis les règles callback.  
Ceci permettra d'éviter le code redondant et aussi de ré-utiliser les messages d'erreurs.

__Exemple:__

```php
<?php
// (...)

class MyModel extends BaseModel
{
    public function __construct(array $attributes = [])
    {
        parent::__construct($attributes);

        $this->validation = [
            'is_deleted' => V::optional(V::boolType()),
            'deleted_at' => V::callback([$this, 'checkDeletedAt']),
        ];
    }

    public function checkDeletedAt()
    {
        if (!$this->is_deleted) {
            return V::nullType();
        }
        return V::notEmpty()->date();
    }
}
```