### PR TITLE
Ajoute le champ `park_id` aux unités de matériel

### DIFF
--- a/server/src/database/migrations/20210105140817_add_park_id_in_material_unit.php
+++ b/server/src/database/migrations/20210105140817_add_park_id_in_material_unit.php
@@ -1,0 +1,26 @@
+<?php
+use Phinx\Migration\AbstractMigration;
+
+class AddParkIdInMaterialUnit extends AbstractMigration
+{
+    public function up()
+    {
+        $table = $this->table('material_units');
+        $table
+            ->addColumn('park_id', 'integer', ['after' => 'serial_number'])
+            ->addForeignKey('park_id', 'parks', 'id', [
+                'delete' => 'CASCADE',
+                'update' => 'NO_ACTION',
+                'constraint' => 'fk_material_unit_park',
+            ])
+            ->save();
+    }
+
+    public function down()
+    {
+        $table = $this->table('material_units');
+        $table
+            ->removeColumn('park_id')
+            ->save();
+    }
+}

--- a/server/tests/Fixtures/seed/material_units.json
+++ b/server/tests/Fixtures/seed/material_units.json
@@ -2,24 +2,28 @@
     {
         "id": 1,
         "material_id": 6,
+        "park_id": 1,
         "serial_number": "XR18-1",
         "is_broken": false
     },
     {
         "id": 2,
         "material_id": 6,
+        "park_id": 1,
         "serial_number": "XR18-2",
         "is_broken": false
     },
     {
         "id": 3,
         "material_id": 6,
+        "park_id": 2,
         "serial_number": "XR18-3",
         "is_broken": true
     },
     {
         "id": 4,
         "material_id": 7,
+        "park_id": 2,
         "serial_number": "VHCL-1",
         "is_broken": false
     }


### PR DESCRIPTION
J'avais oublié ce champ dans l'implémentation initiale.

@polosson Je merge direct car j'en ai besoin rapidement, n'hésites pas à commenter si il y a quoi que ce soit à modifier.