### PR TITLE
Ajoute un système de recherche dans le choix des bénéficiaires et techniciens (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Ce projet adhère au principe du [Semantic Versioning](https://semver.org/spec/v
 - Améliorations internes de la validation des données.
 - Ajoute une page de vue du matériel en détail.
 - Utilise des onglets dans la page de vue du matériel.
+- Dans l'édition d'événements, la recherche directe des bénéficiaires et techniciens dans le champ multiple permet de tous les retrouver (#36).
 
 ## 0.10.2 (2020-11-16)
 

--- a/client/src/components/MultipleItem/MultipleItem.vue
+++ b/client/src/components/MultipleItem/MultipleItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="MultipleItem">
     <div
-      v-for="(itemData, index) in notSavedSelectedItem"
+      v-for="(itemData, index) in notSavedSelectedItems"
       :key="itemData.id || `unknown-${index}`"
       class="MultipleItem__item FormField"
     >
@@ -16,7 +16,7 @@
           <i class="fas fa-exclamation-triangle" />
           {{$t('item-not-found', { item: $t(label) })}}
         </span>
-        <span v-else>{{ getItemLabel(itemData) }}</span>
+        <span v-else>{{ getItemLabel(itemData) || 'N/A' }}</span>
       </div>
       <button
         class="MultipleItem__item-action-btn danger"

--- a/client/src/components/MultipleItem/index.js
+++ b/client/src/components/MultipleItem/index.js
@@ -1,7 +1,6 @@
 import VueSelect from 'vue-select';
 import { debounce } from 'debounce';
 import { DEBOUNCE_WAIT } from '@/config/constants';
-import formatOptions from '@/utils/formatOptions';
 
 export default {
   name: 'MultipleItem',
@@ -13,13 +12,15 @@ export default {
     field: String,
     selectedItems: Array,
     createItemPath: String,
+    formatOptions: Function,
+    getItemLabel: Function,
   },
   data() {
     const defaultItem = { value: null, label: this.$t('please-choose') };
 
     return {
       itemsIds: this.selectedItems.map((item) => item.id),
-      notSavedSelectedItem: [...this.selectedItems],
+      notSavedSelectedItems: [...this.selectedItems],
       minSearchCharacters: 2,
       askNewItem: false,
       fieldOptions: [],
@@ -46,47 +47,16 @@ export default {
     // - We're not using arrow function here because we need access to 'this'
     // eslint-disable-next-line func-names
     search: debounce(function (loading, search) {
-      const params = {
-        ...this.fetchParams,
-        search,
-        limit: 10,
-      };
+      const params = { ...this.fetchParams, search, limit: 10 };
       this.$http.get(this.fetchEntity, { params })
         .then(({ data }) => {
-          const items = formatOptions(
-            data.data,
-            ['last_name', 'first_name', '−', 'company.legal_name', '−', 'locality'],
-          );
-          this.fieldOptions = items;
+          this.fieldOptions = this.formatOptions(data.data);
         })
         .catch(console.error)
         .finally(() => {
           loading(false);
         });
     }, DEBOUNCE_WAIT),
-
-    getItemLabel(itemData) {
-      const {
-        tempLabel,
-        first_name: firstName,
-        last_name: lastName,
-        company,
-        locality,
-      } = itemData;
-
-      if (tempLabel) {
-        return tempLabel;
-      }
-
-      let label = `${lastName} ${firstName}`;
-      if (company) {
-        label += ` − ${company.legal_name}`;
-      }
-      if (locality) {
-        label += ` − ${locality}`;
-      }
-      return label;
-    },
 
     startAddItem(e) {
       e.preventDefault();
@@ -100,10 +70,7 @@ export default {
 
       const { value, label } = this.newItem;
       this.itemsIds.push(value);
-      this.notSavedSelectedItem.push({
-        id: value,
-        tempLabel: label.replace(/\s−$/, ''),
-      });
+      this.notSavedSelectedItems.push({ id: value, label });
 
       this.askNewItem = false;
       this.newItem = this.defaultItem;
@@ -121,7 +88,7 @@ export default {
       this.itemsIds = this.itemsIds.filter(
         (_id) => _id !== id,
       );
-      this.notSavedSelectedItem = this.notSavedSelectedItem.filter(
+      this.notSavedSelectedItems = this.notSavedSelectedItems.filter(
         (item) => item.id !== id,
       );
       this.$emit('itemsUpdated', this.itemsIds);

--- a/client/src/components/MultipleItem/index.js
+++ b/client/src/components/MultipleItem/index.js
@@ -1,0 +1,130 @@
+import VueSelect from 'vue-select';
+import { debounce } from 'debounce';
+import { DEBOUNCE_WAIT } from '@/config/constants';
+import formatOptions from '@/utils/formatOptions';
+
+export default {
+  name: 'MultipleItem',
+  components: { VueSelect },
+  props: {
+    fetchEntity: String,
+    fetchParams: Object,
+    label: String,
+    field: String,
+    selectedItems: Array,
+    createItemPath: String,
+  },
+  data() {
+    const defaultItem = { value: null, label: this.$t('please-choose') };
+
+    return {
+      itemsIds: this.selectedItems.map((item) => item.id),
+      notSavedSelectedItem: [...this.selectedItems],
+      minSearchCharacters: 2,
+      askNewItem: false,
+      fieldOptions: [],
+      newItem: defaultItem,
+      defaultItem,
+    };
+  },
+  computed: {
+    selectableOptions() {
+      return this.fieldOptions.filter(
+        (option) => !this.itemsIds.includes(option.value),
+      );
+    },
+  },
+  methods: {
+    handleSearch(searchTerm, loading) {
+      if (searchTerm.length < this.minSearchCharacters) {
+        return;
+      }
+      loading(true);
+      this.search(loading, searchTerm);
+    },
+
+    // - We're not using arrow function here because we need access to 'this'
+    // eslint-disable-next-line func-names
+    search: debounce(function (loading, search) {
+      const params = {
+        ...this.fetchParams,
+        search,
+        limit: 10,
+      };
+      this.$http.get(this.fetchEntity, { params })
+        .then(({ data }) => {
+          const items = formatOptions(
+            data.data,
+            ['last_name', 'first_name', '−', 'company.legal_name', '−', 'locality'],
+          );
+          this.fieldOptions = items;
+        })
+        .catch(console.error)
+        .finally(() => {
+          loading(false);
+        });
+    }, DEBOUNCE_WAIT),
+
+    getItemLabel(itemData) {
+      const {
+        tempLabel,
+        first_name: firstName,
+        last_name: lastName,
+        company,
+        locality,
+      } = itemData;
+
+      if (tempLabel) {
+        return tempLabel;
+      }
+
+      let label = `${lastName} ${firstName}`;
+      if (company) {
+        label += ` − ${company.legal_name}`;
+      }
+      if (locality) {
+        label += ` − ${locality}`;
+      }
+      return label;
+    },
+
+    startAddItem(e) {
+      e.preventDefault();
+      this.askNewItem = true;
+    },
+
+    insertNewItem() {
+      if (!this.newItem || !this.newItem.value) {
+        return;
+      }
+
+      const { value, label } = this.newItem;
+      this.itemsIds.push(value);
+      this.notSavedSelectedItem.push({
+        id: value,
+        tempLabel: label.replace(/\s−$/, ''),
+      });
+
+      this.askNewItem = false;
+      this.newItem = this.defaultItem;
+
+      this.$emit('itemsUpdated', this.itemsIds);
+    },
+
+    cancelNewItem(e) {
+      e.preventDefault();
+      this.askNewItem = false;
+      this.newItem = this.defaultItem;
+    },
+
+    removeItem(id) {
+      this.itemsIds = this.itemsIds.filter(
+        (_id) => _id !== id,
+      );
+      this.notSavedSelectedItem = this.notSavedSelectedItem.filter(
+        (item) => item.id !== id,
+      );
+      this.$emit('itemsUpdated', this.itemsIds);
+    },
+  },
+};

--- a/client/src/locale/en/common.js
+++ b/client/src/locale/en/common.js
@@ -30,6 +30,13 @@ export default {
   'copied-in-clipboard': "Copied in clipboard!",
 
   'please-choose': "Please choose...",
+  'start-typing-to-search': "Start typing to search...",
+  'type-at-least-count-chars-to-search': [
+    "Type again, at least {count} character to search...",
+    "Type again, at least {count} characters to search...",
+  ],
+  'no-result-found-try-another-search': "No results. Try another search term.",
+  'create-select-item-label': "Create a {label}",
   'add-item': "Add a {item}",
   'remove-item': "Remove this {item}",
   'cancel-add-item': "Cancel adding {item}",

--- a/client/src/locale/fr/common.js
+++ b/client/src/locale/fr/common.js
@@ -30,6 +30,13 @@ export default {
   'copied-in-clipboard': "Copié dans le presse-papier\u00a0!",
 
   'please-choose': "Veuillez choisir...",
+  'start-typing-to-search': "Commencez à écrire pour rechercher...",
+  'type-at-least-count-chars-to-search': [
+    "Entrez encore au moins {count} lettre pour rechercher...",
+    "Entrez encore au moins {count} lettres pour rechercher...",
+  ],
+  'no-result-found-try-another-search': "Aucun résultat. Essayez avec une autre recherche.",
+  'create-select-item-label': "Créer un {label}",
   'add-item': "Ajouter un {item}",
   'remove-item': "Enlever ce {item}",
   'cancel-add-item': "Annuler l'ajout de {item}",

--- a/client/src/pages/Event/Step2/Step2.vue
+++ b/client/src/pages/Event/Step2/Step2.vue
@@ -12,6 +12,8 @@
         :selectedItems="event.beneficiaries"
         @itemsUpdated="updateItems"
         createItemPath="/beneficiaries/new"
+        :formatOptions="formatItemOptions"
+        :getItemLabel="getItemLabel"
       />
       <p v-if="showBillingHelp" class="EventStep2__help">
         <i class="fas fa-info-circle" />

--- a/client/src/pages/Event/Step2/Step2.vue
+++ b/client/src/pages/Event/Step2/Step2.vue
@@ -7,9 +7,11 @@
       <MultipleItem
         label="beneficiary"
         field="full_name"
-        :field-options="beneficiariesOptions"
-        :initial-items-ids="beneficiariesIds"
+        fetchEntity="persons"
+        :fetchParams="fetchParams"
+        :selectedItems="event.beneficiaries"
         @itemsUpdated="updateItems"
+        createItemPath="/beneficiaries/new"
       />
       <p v-if="showBillingHelp" class="EventStep2__help">
         <i class="fas fa-info-circle" />

--- a/client/src/pages/Event/Step2/index.js
+++ b/client/src/pages/Event/Step2/index.js
@@ -1,5 +1,7 @@
 import Config from '@/config/globalConfig';
 import MultipleItem from '@/components/MultipleItem/MultipleItem.vue';
+import getPersonItemLabel from '@/utils/getPersonItemLabel';
+import formatOptions from '@/utils/formatOptions';
 import EventStore from '../EventStore';
 
 export default {
@@ -27,6 +29,14 @@ export default {
         .concat(savedList.filter((id) => !ids.includes(id)));
 
       EventStore.commit('setIsSaved', listDifference.length === 0);
+    },
+
+    formatItemOptions(data) {
+      return formatOptions(data, getPersonItemLabel);
+    },
+
+    getItemLabel(itemData) {
+      return getPersonItemLabel(itemData);
     },
 
     saveAndBack(e) {

--- a/client/src/pages/Event/Step2/index.js
+++ b/client/src/pages/Event/Step2/index.js
@@ -1,6 +1,5 @@
 import Config from '@/config/globalConfig';
 import MultipleItem from '@/components/MultipleItem/MultipleItem.vue';
-import formatOptions from '@/utils/formatOptions';
 import EventStore from '../EventStore';
 
 export default {
@@ -10,30 +9,15 @@ export default {
   data() {
     return {
       beneficiariesIds: this.event.beneficiaries.map((benef) => benef.id),
-      beneficiariesOptions: [],
       showBillingHelp: Config.billingMode !== 'none',
+      fetchParams: { tags: [Config.beneficiaryTagName] },
       errors: {},
     };
   },
   mounted() {
-    this.getEntities();
     EventStore.commit('setIsSaved', true);
   },
   methods: {
-    getEntities() {
-      this.$emit('loading');
-      const params = { tags: [Config.beneficiaryTagName] };
-      this.$http.get('persons', { params })
-        .then(({ data }) => {
-          this.beneficiariesOptions = formatOptions(
-            data.data,
-            ['first_name', 'last_name', '−', 'company.legal_name', '−', 'locality'],
-          );
-          this.$emit('stopLoading');
-        })
-        .catch(this.displayError);
-    },
-
     updateItems(ids) {
       this.beneficiariesIds = ids;
 

--- a/client/src/pages/Event/Step3/Step3.vue
+++ b/client/src/pages/Event/Step3/Step3.vue
@@ -12,6 +12,8 @@
         :selectedItems="event.assignees"
         @itemsUpdated="updateItems"
         createItemPath="/technicians/new"
+        :formatOptions="formatItemOptions"
+        :getItemLabel="getItemLabel"
       />
     </section>
     <section class="Form__actions">

--- a/client/src/pages/Event/Step3/Step3.vue
+++ b/client/src/pages/Event/Step3/Step3.vue
@@ -7,9 +7,11 @@
       <MultipleItem
         label="technician"
         field="full_name"
-        :field-options="assigneesOptions"
-        :initial-items-ids="assigneesIds"
+        fetchEntity="persons"
+        :fetchParams="fetchParams"
+        :selectedItems="event.assignees"
         @itemsUpdated="updateItems"
+        createItemPath="/technicians/new"
       />
     </section>
     <section class="Form__actions">

--- a/client/src/pages/Event/Step3/index.js
+++ b/client/src/pages/Event/Step3/index.js
@@ -1,5 +1,7 @@
 import Config from '@/config/globalConfig';
 import MultipleItem from '@/components/MultipleItem/MultipleItem.vue';
+import getPersonItemLabel from '@/utils/getPersonItemLabel';
+import formatOptions from '@/utils/formatOptions';
 import EventStore from '../EventStore';
 
 export default {
@@ -26,6 +28,14 @@ export default {
         .concat(savedList.filter((id) => !ids.includes(id)));
 
       EventStore.commit('setIsSaved', listDifference.length === 0);
+    },
+
+    formatItemOptions(data) {
+      return formatOptions(data, getPersonItemLabel);
+    },
+
+    getItemLabel(itemData) {
+      return getPersonItemLabel(itemData);
     },
 
     saveAndBack(e) {

--- a/client/src/pages/Event/Step3/index.js
+++ b/client/src/pages/Event/Step3/index.js
@@ -1,6 +1,5 @@
 import Config from '@/config/globalConfig';
 import MultipleItem from '@/components/MultipleItem/MultipleItem.vue';
-import formatOptions from '@/utils/formatOptions';
 import EventStore from '../EventStore';
 
 export default {
@@ -10,29 +9,14 @@ export default {
   data() {
     return {
       assigneesIds: this.event.assignees.map((assignee) => assignee.id),
-      assigneesOptions: [],
+      fetchParams: { tags: [Config.technicianTagName] },
       errors: {},
     };
   },
   mounted() {
-    this.getEntities();
     EventStore.commit('setIsSaved', true);
   },
   methods: {
-    getEntities() {
-      this.$emit('loading');
-      const params = { tags: [Config.technicianTagName] };
-      this.$http.get('persons', { params })
-        .then(({ data }) => {
-          this.assigneesOptions = formatOptions(
-            data.data,
-            ['first_name', 'last_name', '−', 'phone'],
-          );
-          this.$emit('stopLoading');
-        })
-        .catch(this.displayError);
-    },
-
     updateItems(ids) {
       this.assigneesIds = ids;
 

--- a/client/src/pages/Material/index.js
+++ b/client/src/pages/Material/index.js
@@ -194,11 +194,7 @@ export default {
         return;
       }
 
-      this.subCategoriesOptions = formatOptions(
-        category.sub_categories,
-        ['name'],
-        this.$t('please-choose'),
-      );
+      this.subCategoriesOptions = formatOptions(category.sub_categories, null, this.$t('please-choose'));
 
       this.refreshSubCategorySelect();
     },

--- a/client/src/stores/categories.js
+++ b/client/src/stores/categories.js
@@ -12,8 +12,7 @@ export default {
   getters: {
     options: (state, getters, rootState) => {
       const { locale, translations } = rootState.i18n;
-      const emptyLabel = translations[locale]['please-choose'];
-      return formatOptions(state.list, ['name'], emptyLabel);
+      return formatOptions(state.list, null, translations[locale]['please-choose']);
     },
 
     categoryName: (state) => (categoryId) => {

--- a/client/src/stores/companies.js
+++ b/client/src/stores/companies.js
@@ -12,8 +12,11 @@ export default {
   getters: {
     options: (state, getters, rootState) => {
       const { locale, translations } = rootState.i18n;
-      const emptyLabel = translations[locale]['please-choose'];
-      return formatOptions(state.list, ['legal_name'], emptyLabel);
+      return formatOptions(
+        state.list,
+        (item) => item.legal_name,
+        translations[locale]['please-choose'],
+      );
     },
   },
   mutations: {

--- a/client/src/stores/countries.js
+++ b/client/src/stores/countries.js
@@ -12,8 +12,7 @@ export default {
   getters: {
     options: (state, getters, rootState) => {
       const { locale, translations } = rootState.i18n;
-      const emptyLabel = translations[locale]['please-choose'];
-      return formatOptions(state.list, ['name'], emptyLabel);
+      return formatOptions(state.list, null, translations[locale]['please-choose']);
     },
   },
   mutations: {

--- a/client/src/stores/parks.js
+++ b/client/src/stores/parks.js
@@ -12,8 +12,7 @@ export default {
   getters: {
     options: (state, getters, rootState) => {
       const { locale, translations } = rootState.i18n;
-      const emptyLabel = translations[locale]['please-choose'];
-      return formatOptions(state.list, ['name'], emptyLabel);
+      return formatOptions(state.list, null, translations[locale]['please-choose']);
     },
 
     parkName: (state) => (parkId) => {

--- a/client/src/stores/tags.js
+++ b/client/src/stores/tags.js
@@ -17,7 +17,6 @@ export default {
   getters: {
     options: (state, getters) => formatOptions(
       state.list.filter((tag) => !getters.isProtected(tag.name)),
-      ['name'],
     ),
 
     isProtected: (state) => (tagName) => (

--- a/client/src/utils/formatOptions.js
+++ b/client/src/utils/formatOptions.js
@@ -1,8 +1,6 @@
 const formatOptions = (data, labelFields = ['name'], emptyLabel = null) => {
   if (!data || data.length === 0) {
-    return [
-      { value: '', label: 'N/A' },
-    ];
+    return [];
   }
 
   const options = data.map(

--- a/client/src/utils/formatOptions.js
+++ b/client/src/utils/formatOptions.js
@@ -1,34 +1,13 @@
-const formatOptions = (data, labelFields = ['name'], emptyLabel = null) => {
+const formatOptions = (data, getLabel = null, emptyLabel = null) => {
   if (!data || data.length === 0) {
     return [];
   }
 
-  const options = data.map(
-    (item) => {
-      const labelParts = labelFields.map((field) => {
-        if (field.match(/\.+/)) {
-          let itemField = item;
-          field.split('.').forEach((fieldPart) => {
-            if (itemField && Object.keys(itemField).includes(fieldPart)) {
-              itemField = itemField[fieldPart];
-            } else {
-              itemField = null;
-            }
-          });
-          return itemField;
-        }
-
-        if (Object.keys(item).includes(field)) {
-          return item[field];
-        }
-
-        return field;
-      });
-
-      const label = labelParts.filter((_label) => !!_label).join(' ');
-      return { value: item.id, label };
-    },
-  );
+  const options = data.map((item) => {
+    const value = item.id;
+    const label = getLabel ? getLabel(item) : (item.name || 'N/A');
+    return { value, label };
+  });
 
   if (emptyLabel) {
     options.unshift({ value: '', label: emptyLabel });

--- a/client/src/utils/getPersonItemLabel.js
+++ b/client/src/utils/getPersonItemLabel.js
@@ -1,0 +1,24 @@
+const getPersonItemLabel = (itemData) => {
+  const {
+    label: alreadySetLabel,
+    first_name: firstName,
+    last_name: lastName,
+    company,
+    locality,
+  } = itemData;
+
+  if (alreadySetLabel) {
+    return alreadySetLabel;
+  }
+
+  let label = `${lastName} ${firstName}`;
+  if (company && company.legal_name.length > 0) {
+    label += ` − ${company.legal_name}`;
+  }
+  if (locality && locality.length > 0) {
+    label += ` − ${locality}`;
+  }
+  return label;
+};
+
+export default getPersonItemLabel;

--- a/client/tests/unit/utils/formatOptions.spec.js
+++ b/client/tests/unit/utils/formatOptions.spec.js
@@ -1,14 +1,10 @@
 import formatOptions from '@/utils/formatOptions';
 
 describe('formatOptions', () => {
-  const emptyOptions = [
-    { value: '', label: 'N/A' },
-  ];
-
   it('returns an array with only one empty option', () => {
-    expect(formatOptions()).toEqual(emptyOptions);
-    expect(formatOptions(null)).toEqual(emptyOptions);
-    expect(formatOptions([])).toEqual(emptyOptions);
+    expect(formatOptions()).toEqual([]);
+    expect(formatOptions(null)).toEqual([]);
+    expect(formatOptions([])).toEqual([]);
   });
 
   it('returns a set of options with given list of entities', () => {

--- a/client/tests/unit/utils/formatOptions.spec.js
+++ b/client/tests/unit/utils/formatOptions.spec.js
@@ -19,7 +19,7 @@ describe('formatOptions', () => {
     ]);
   });
 
-  it('returns a set of options with given list of entities and custom fields to create label', () => {
+  it('returns a set of options with given list of entities and custom function to create label', () => {
     const entities = [
       { id: 1, title: 'test1', phone: '0123456789' },
       {
@@ -29,9 +29,10 @@ describe('formatOptions', () => {
         company: { id: 1, name: 'Testing' },
       },
     ];
-    const options = formatOptions(entities, ['title', 'phone', '−', 'company.name']);
+    const getLabel = ({ title, phone, company }) => `${title} ${phone} − ${company?.name || ''}`;
+    const options = formatOptions(entities, getLabel);
     expect(options).toEqual([
-      { value: 1, label: 'test1 0123456789 −' },
+      { value: 1, label: 'test1 0123456789 − ' },
       { value: 2, label: 'test2 0987654321 − Testing' },
     ]);
   });
@@ -41,7 +42,7 @@ describe('formatOptions', () => {
       { id: 1, name: 'test1' },
       { id: 2, name: 'test2' },
     ];
-    const options = formatOptions(entities, undefined, 'Choose...');
+    const options = formatOptions(entities, null, 'Choose...');
     expect(options).toEqual([
       { value: '', label: 'Choose...' },
       { value: 1, label: 'test1' },

--- a/client/tests/unit/utils/getPersonItemLabel.spec.js
+++ b/client/tests/unit/utils/getPersonItemLabel.spec.js
@@ -1,0 +1,47 @@
+import getPersonItemLabel from '@/utils/getPersonItemLabel';
+
+describe('getPersonItemLabel', () => {
+  it('returns a label string with name from basic person data', () => {
+    const person = {
+      id: 1,
+      first_name: 'Jean',
+      last_name: 'Testing',
+    };
+    expect(getPersonItemLabel(person)).toEqual('Testing Jean');
+  });
+
+  it('returns a label string with name and company when defined in person data', () => {
+    const person = {
+      id: 1,
+      first_name: 'Jean',
+      last_name: 'Testing',
+      company: { legal_name: 'Pulsanova' },
+    };
+    expect(getPersonItemLabel(person)).toEqual('Testing Jean − Pulsanova');
+  });
+
+  it('returns a label string with name and locality when defined in person data', () => {
+    const person = {
+      id: 1,
+      first_name: 'Jean',
+      last_name: 'Testing',
+      locality: 'French Alps',
+    };
+    expect(getPersonItemLabel(person)).toEqual('Testing Jean − French Alps');
+  });
+
+  it('returns a label string with name, company and locality when defined in person data', () => {
+    const person = {
+      id: 1,
+      first_name: 'Jean',
+      last_name: 'Testing',
+      locality: 'French Alps',
+      company: { legal_name: 'Pulsanova' },
+    };
+    expect(getPersonItemLabel(person)).toEqual('Testing Jean − Pulsanova − French Alps');
+  });
+
+  it('returns the same label when already defined', () => {
+    expect(getPersonItemLabel({ id: 1, label: 'test' })).toEqual('test');
+  });
+});

--- a/server/src/App/Controllers/BaseController.php
+++ b/server/src/App/Controllers/BaseController.php
@@ -43,6 +43,7 @@ abstract class BaseController
         $searchTerm = $request->getQueryParam('search', null);
         $searchField = $request->getQueryParam('searchBy', null);
         $orderBy = $request->getQueryParam('orderBy', null);
+        $limit = $request->getQueryParam('limit', null);
         $ascending = (bool)$request->getQueryParam('ascending', true);
         $withDeleted = (bool)$request->getQueryParam('deleted', false);
 
@@ -50,7 +51,7 @@ abstract class BaseController
             ->setOrderBy($orderBy, $ascending)
             ->setSearch($searchTerm, $searchField)
             ->getAll($withDeleted)
-            ->paginate($this->itemsCount);
+            ->paginate($limit ? (int)$limit : $this->itemsCount);
 
         $basePath = $request->getUri()->getPath();
         $params = $request->getQueryParams();

--- a/server/src/App/Controllers/Traits/Taggable.php
+++ b/server/src/App/Controllers/Traits/Taggable.php
@@ -16,6 +16,7 @@ trait Taggable
         $searchField = $request->getQueryParam('searchBy', null);
         $tags = $request->getQueryParam('tags', []);
         $orderBy = $request->getQueryParam('orderBy', null);
+        $limit = $request->getQueryParam('limit', null);
         $ascending = (bool)$request->getQueryParam('ascending', true);
         $withDeleted = (bool)$request->getQueryParam('deleted', false);
 
@@ -23,7 +24,7 @@ trait Taggable
             ->setOrderBy($orderBy, $ascending)
             ->setSearch($searchTerm, $searchField)
             ->getAllFilteredOrTagged([], $tags, $withDeleted)
-            ->paginate($this->itemsCount);
+            ->paginate($limit ? (int)$limit : $this->itemsCount);
 
         $basePath = $request->getUri()->getPath();
         $params   = $request->getQueryParams();

--- a/server/src/App/Models/Person.php
+++ b/server/src/App/Models/Person.php
@@ -19,7 +19,7 @@ class Person extends BaseModel
 
     protected $table = 'persons';
 
-    protected $orderField = 'first_name';
+    protected $orderField = 'last_name';
 
     protected $allowedSearchFields = ['full_name', 'first_name', 'last_name', 'nickname', 'email'];
     protected $searchField = 'full_name';

--- a/server/tests/endpoints/PersonsTest.php
+++ b/server/tests/endpoints/PersonsTest.php
@@ -114,6 +114,96 @@ final class PersonsTest extends ApiTestCase
         $this->assertResponsePaginatedData(0, '/api/persons', 'deleted=1');
     }
 
+    public function testGetPersonsWithLimit()
+    {
+        $this->client->get('/api/persons?limit=2');
+        $this->assertStatusCode(SUCCESS_OK);
+        $this->assertResponseData([
+            'pagination' => [
+                'current_page'   => 1,
+                'from'           => 1,
+                'last_page'      => 2,
+                'path'           => '/api/persons',
+                'first_page_url' => '/api/persons?limit=2&page=1',
+                'next_page_url'  => '/api/persons?limit=2&page=2',
+                'prev_page_url'  => null,
+                'last_page_url'  => '/api/persons?limit=2&page=2',
+                'per_page'       => 2,
+                'to'             => 2,
+                'total'          => 3,
+            ],
+            'data' => [
+                [
+                    'id'          => 3,
+                    'first_name'  => 'Client',
+                    'last_name'   => 'Benef',
+                    'full_name'   => 'Client Benef',
+                    'nickname'    => null,
+                    'email'       => 'client@beneficiaires.com',
+                    'phone'       => '+33123456789',
+                    'street'      => '156 bis, avenue des tests poussés',
+                    'postal_code' => '88080',
+                    'locality'    => 'Wazzaville',
+                    'user_id'     => null,
+                    'country_id'  => null,
+                    'company_id'  => null,
+                    'note'        => null,
+                    'created_at'  => null,
+                    'updated_at'  => null,
+                    'deleted_at'  => null,
+                    'company'     => null,
+                    'country'     => null,
+                ],
+                [
+                    'id'          => 1,
+                    'first_name'  => 'Jean',
+                    'last_name'   => 'Fountain',
+                    'full_name'   => 'Jean Fountain',
+                    'nickname'    => null,
+                    'email'       => 'tester@robertmanager.net',
+                    'phone'       => null,
+                    'street'      => "1, somewhere av.",
+                    'postal_code' => '1234',
+                    'locality'    => "Megacity",
+                    'user_id'     => 1,
+                    'country_id'  => 1,
+                    'company_id'  => 1,
+                    'note'        => null,
+                    'created_at'  => null,
+                    'updated_at'  => null,
+                    'deleted_at'  => null,
+                    'company'     => [
+                        'id'          => 1,
+                        'legal_name'  => 'Testing, Inc',
+                        'street'      => '1, company st.',
+                        'postal_code' => '1234',
+                        'locality'    => 'Megacity',
+                        'country_id'  => 1,
+                        'phone'       => '+4123456789',
+                        'note'        => 'Just for tests',
+                        'created_at'  => null,
+                        'updated_at'  => null,
+                        'deleted_at'  => null,
+                        'country'     => [
+                            'id'   => 1,
+                            'name' => 'France',
+                            'code' => 'FR',
+                        ],
+                    ],
+                    'country' => [
+                        'id'   => 1,
+                        'name' => 'France',
+                        'code' => 'FR',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->client->get('/api/persons?deleted=1');
+        $this->assertStatusCode(SUCCESS_OK);
+        $this->assertResponsePaginatedData(0, '/api/persons', 'deleted=1');
+    }
+
     public function testGetPersonNotFound()
     {
         $this->client->get('/api/persons/999');


### PR DESCRIPTION
Note: j'en ai profité pour ajouter un moyen d'overwrite le nombre d'items par page qu'on veut récupérer, en utilisant la querystring `limit=10` par ex. pour tous les endpoints utilisant `getAll()`.