### PR TITLE
Ajout des matériels liés aux événements et ajout des événements liés aux matériels (api) (#252) 

### DIFF
--- a/server/src/App/Controllers/EventController.php
+++ b/server/src/App/Controllers/EventController.php
@@ -39,7 +39,9 @@ class EventController extends BaseController
             ->with('Technicians');
 
         if ($withMaterials) {
-            $results->with('Materials');
+            $results->with(['Materials' => function ($q) {
+                $q->orderBy('name', 'asc');
+            }]);
         }
 
         $data = $results->get()->toArray();

--- a/server/src/App/Controllers/EventController.php
+++ b/server/src/App/Controllers/EventController.php
@@ -39,9 +39,7 @@ class EventController extends BaseController
             ->with('Technicians');
 
         if ($withMaterials) {
-            $results->with(['Materials' => function ($q) {
-                $q->orderBy('name');
-            }]);
+            $results->with('Materials');
         }
 
         $data = $results->get()->toArray();

--- a/server/src/App/Controllers/EventController.php
+++ b/server/src/App/Controllers/EventController.php
@@ -30,12 +30,15 @@ class EventController extends BaseController
         $startDate = $request->getQueryParam('start', null);
         $endDate = $request->getQueryParam('end', null);
         $deleted = (bool)$request->getQueryParam('deleted', false);
+        $withMaterials = (bool)$request->getQueryParam('materials', false);
 
         $results = (new Event)
             ->setSearchPeriod($startDate, $endDate)
             ->getAll($deleted)
             ->with('Beneficiaries:persons.id,first_name,last_name')
             ->with('Technicians');
+
+        if($withMaterials == true) $results->with('Materials');
 
         $data = $results->get()->toArray();
         $useMultipleParks = Park::count() > 1;

--- a/server/src/App/Controllers/EventController.php
+++ b/server/src/App/Controllers/EventController.php
@@ -39,7 +39,9 @@ class EventController extends BaseController
             ->with('Technicians');
 
         if ($withMaterials) {
-            $results->with('Materials');
+            $results->with(['Materials' => function ($q) {
+                $q->orderBy('name');
+            }]);
         }
 
         $data = $results->get()->toArray();

--- a/server/src/App/Controllers/EventController.php
+++ b/server/src/App/Controllers/EventController.php
@@ -30,7 +30,7 @@ class EventController extends BaseController
         $startDate = $request->getQueryParam('start', null);
         $endDate = $request->getQueryParam('end', null);
         $deleted = (bool)$request->getQueryParam('deleted', false);
-        $with_materials = (bool)$request->getQueryParam('materials', false);
+        $withMaterials = (bool)$request->getQueryParam('with-materials', false);
 
         $results = (new Event)
             ->setSearchPeriod($startDate, $endDate)
@@ -38,7 +38,7 @@ class EventController extends BaseController
             ->with('Beneficiaries:persons.id,first_name,last_name')
             ->with('Technicians');
 
-        if ($with_materials == true) {
+        if ($withMaterials) {
             $results->with('Materials');
         }
 

--- a/server/src/App/Controllers/EventController.php
+++ b/server/src/App/Controllers/EventController.php
@@ -30,7 +30,7 @@ class EventController extends BaseController
         $startDate = $request->getQueryParam('start', null);
         $endDate = $request->getQueryParam('end', null);
         $deleted = (bool)$request->getQueryParam('deleted', false);
-        $withMaterials = (bool)$request->getQueryParam('materials', false);
+        $with_materials = (bool)$request->getQueryParam('materials', false);
 
         $results = (new Event)
             ->setSearchPeriod($startDate, $endDate)
@@ -38,7 +38,9 @@ class EventController extends BaseController
             ->with('Beneficiaries:persons.id,first_name,last_name')
             ->with('Technicians');
 
-        if($withMaterials == true) $results->with('Materials');
+        if ($with_materials == true) {
+            $results->with('Materials');
+        }
 
         $data = $results->get()->toArray();
         $useMultipleParks = Park::count() > 1;

--- a/server/src/App/Controllers/MaterialController.php
+++ b/server/src/App/Controllers/MaterialController.php
@@ -53,7 +53,7 @@ class MaterialController extends BaseController
         $dateForQuantities = $request->getQueryParam('dateForQuantities', null);
         $withDeleted = (bool)$request->getQueryParam('deleted', false);
         $tags = $request->getQueryParam('tags', []);
-        $withEvents = (bool)$request->getQueryParam('events', false);
+        $withEvents = (bool)$request->getQueryParam('with-events', false);
 
         $options = [];
         if ($parkId) {
@@ -78,11 +78,12 @@ class MaterialController extends BaseController
         } else {
             $model = $model->getAllFilteredOrTagged($options, $tags, $withDeleted);
         }
-        if ($withEvents == true) {
-            $model->with('Events', function ($query) {
-                $query->where('Events.end_date', '>=', Carbon::now());
-            })
-            ->get();
+        if ($withEvents) {
+            $model
+                ->with('Events', function ($query) {
+                    $query->where('end_date', '>=', Carbon::now());
+                })
+                ->get();
         }
 
         $results = $this->paginate($request, $model);

--- a/server/src/App/Controllers/MaterialController.php
+++ b/server/src/App/Controllers/MaterialController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Robert2\API\Controllers;
 
 use DI\Container;
+use Illuminate\Support\Carbon;
 use Robert2\API\Config\Config;
 use Robert2\API\Controllers\Traits\Taggable;
 use Robert2\API\Controllers\Traits\WithCrud;
@@ -52,6 +53,7 @@ class MaterialController extends BaseController
         $dateForQuantities = $request->getQueryParam('dateForQuantities', null);
         $withDeleted = (bool)$request->getQueryParam('deleted', false);
         $tags = $request->getQueryParam('tags', []);
+        $withEvents = (bool)$request->getQueryParam('events', false);
 
         $options = [];
         if ($parkId) {
@@ -75,6 +77,13 @@ class MaterialController extends BaseController
             $model = $model->getAll($withDeleted);
         } else {
             $model = $model->getAllFilteredOrTagged($options, $tags, $withDeleted);
+        }
+        if ($withEvents == true) {
+            $model->with('Events', function ($query) {
+                $query->where('Events.end_date', '>=', Carbon::now());
+            })
+                ->with('Events')
+                ->get();
         }
 
         $results = $this->paginate($request, $model);

--- a/server/src/App/Controllers/MaterialController.php
+++ b/server/src/App/Controllers/MaterialController.php
@@ -82,8 +82,7 @@ class MaterialController extends BaseController
             $model->with('Events', function ($query) {
                 $query->where('Events.end_date', '>=', Carbon::now());
             })
-                ->with('Events')
-                ->get();
+            ->get();
         }
 
         $results = $this->paginate($request, $model);

--- a/server/tests/endpoints/EventsTest.php
+++ b/server/tests/endpoints/EventsTest.php
@@ -1129,4 +1129,525 @@ final class EventsTest extends ApiTestCase
         $this->assertStatusCode(200);
         $this->assertTrue($responseStream->isReadable());
     }
+
+    public function testGetEventsWithMaterials()
+    {
+        $this->client->get('/api/events?start=2018-01-01&end=2018-12-31&materials=true');
+        $this->assertStatusCode(SUCCESS_OK);
+        $this->assertResponseData([
+            "data" => [
+                [
+                    "id" => 3,
+                    "user_id" => 1,
+                    "title" => "Avant-premier événement",
+                    "description" => null,
+                    "reference" => null,
+                    "start_date" => "2018-12-15 00:00:00",
+                    "end_date" => "2018-12-16 23:59:59",
+                    "is_confirmed" => false,
+                    "is_archived" => true,
+                    "location" => "Brousse",
+                    "is_billable" => false,
+                    "is_return_inventory_done" => false,
+                    "created_at" => null,
+                    "updated_at" => null,
+                    "deleted_at" => null,
+                    "beneficiaries" => [
+                    ],
+                    "technicians" => [
+                    ],
+                    "materials" => [
+                        [
+                            "id" => 3,
+                            "name" => "PAR64 LED",
+                            "description" => "Projecteur PAR64 à LED, avec son set de gélatines",
+                            "reference" => "PAR64LED",
+                            "is_unitary" => false,
+                            "park_id" => 1,
+                            "category_id" => 2,
+                            "sub_category_id" => 3,
+                            "rental_price" => 3.5,
+                            "stock_quantity" => 34,
+                            "out_of_order_quantity" => 4,
+                            "replacement_price" => 89,
+                            "is_hidden_on_bill" => false,
+                            "is_discountable" => true,
+                            "tags" => [
+                                [
+                                    "id" => 3,
+                                    "name" => "pro"
+                                ]
+                            ],
+                            "attributes" => [
+                                [
+                                    "id" => 3,
+                                    "name" => "Puissance",
+                                    "type" => "integer",
+                                    "unit" => "W",
+                                    "value" => 150
+                                ],
+                                [
+                                    "id" => 1,
+                                    "name" => "Poids",
+                                    "type" => "float",
+                                    "unit" => "kg",
+                                    "value" => 0.85
+                                ]
+                            ],
+                            "pivot" => [
+                                "event_id" => 3,
+                                "material_id" => 3,
+                                "id" => 6,
+                                "quantity" => 10,
+                                "quantity_returned" => 0,
+                                "quantity_broken" => 0
+                            ]
+                        ],
+                        [
+                            "id" => 2,
+                            "name" => "Processeur DBX PA2",
+                            "description" => "Système de diffusion numérique",
+                            "reference" => "DBXPA2",
+                            "is_unitary" => false,
+                            "park_id" => 1,
+                            "category_id" => 1,
+                            "sub_category_id" => 2,
+                            "rental_price" => 25.5,
+                            "stock_quantity" => 2,
+                            "out_of_order_quantity" => null,
+                            "replacement_price" => 349.9,
+                            "is_hidden_on_bill" => false,
+                            "is_discountable" => true,
+                            "tags" => [
+                                [
+                                    "id" => 3,
+                                    "name" => "pro"
+                                ]
+                            ],
+                            "attributes" => [
+                                [
+                                    "id" => 3,
+                                    "name" => "Puissance",
+                                    "type" => "integer",
+                                    "unit" => "W",
+                                    "value" => 35
+                                ],
+                                [
+                                    "id" => 1,
+                                    "name" => "Poids",
+                                    "type" => "float",
+                                    "unit" => "kg",
+                                    "value" => 2.2
+                                ]
+                            ],
+                            "pivot" => [
+                                "event_id" => 3,
+                                "material_id" => 2,
+                                "id" => 7,
+                                "quantity" => 1,
+                                "quantity_returned" => 0,
+                                "quantity_broken" => 0
+                            ]
+                        ],
+                        [
+                            "id" => 5,
+                            "name" => "Câble XLR 10m",
+                            "description" => "Câble audio XLR 10 mètres, mâle-femelle",
+                            "reference" => "XLR10",
+                            "is_unitary" => false,
+                            "park_id" => 1,
+                            "category_id" => 1,
+                            "sub_category_id" => null,
+                            "rental_price" => 0.5,
+                            "stock_quantity" => 40,
+                            "out_of_order_quantity" => 8,
+                            "replacement_price" => 9.5,
+                            "is_hidden_on_bill" => true,
+                            "is_discountable" => true,
+                            "tags" => [
+                            ],
+                            "attributes" => [
+                            ],
+                            "pivot" => [
+                                "event_id" => 3,
+                                "material_id" => 5,
+                                "id" => 8,
+                                "quantity" => 12,
+                                "quantity_returned" => 0,
+                                "quantity_broken" => 0
+                            ]
+                        ]
+                    ],
+                    "has_missing_materials" => null,
+                    "has_not_returned_materials" => null,
+                    "parks" => [
+                        1
+                    ]
+                ],
+                [
+                    "id" => 1,
+                    "user_id" => 1,
+                    "title" => "Premier événement",
+                    "description" => null,
+                    "reference" => null,
+                    "start_date" => "2018-12-17 00:00:00",
+                    "end_date" => "2018-12-18 23:59:59",
+                    "is_confirmed" => false,
+                    "is_archived" => false,
+                    "location" => "Gap",
+                    "is_billable" => true,
+                    "is_return_inventory_done" => true,
+                    "created_at" => null,
+                    "updated_at" => null,
+                    "deleted_at" => null,
+                    "beneficiaries" => [
+                        [
+                            "id" => 3,
+                            "first_name" => "Client",
+                            "last_name" => "Benef",
+                            "full_name" => "Client Benef",
+                            "country" => null,
+                            "company" => null,
+                            "pivot" => [
+                                "event_id" => "1",
+                                "person_id" => "3"
+                            ]
+                        ]
+                    ],
+                    "technicians" => [
+                        [
+                            "id" => 1,
+                            "event_id" => 1,
+                            "technician_id" => 1,
+                            "start_time" => "2018-12-17 09:00:00",
+                            "end_time" => "2018-12-18 22:00:00",
+                            "position" => "Régisseur",
+                            "technician" => [
+                                "id" => 1,
+                                "first_name" => "Jean",
+                                "last_name" => "Fountain",
+                                "nickname" => null,
+                                "phone" => null,
+                                "full_name" => "Jean Fountain",
+                                "country" => null,
+                                "company" => null
+                            ]
+                        ],
+                        [
+                            "id" => 2,
+                            "event_id" => 1,
+                            "technician_id" => 2,
+                            "start_time" => "2018-12-18 14:00:00",
+                            "end_time" => "2018-12-18 18:00:00",
+                            "position" => "Technicien plateau",
+                            "technician" => [
+                                "id" => 2,
+                                "first_name" => "Roger",
+                                "last_name" => "Rabbit",
+                                "nickname" => "Riri",
+                                "phone" => null,
+                                "full_name" => "Roger Rabbit",
+                                "country" => null,
+                                "company" => null
+                            ]
+                        ]
+                    ],
+                    "materials" => [
+                        [
+                            "id" => 1,
+                            "name" => "Console Yamaha CL3",
+                            "description" => "Console numérique 64 entrées / 8 sorties + Master + Sub",
+                            "reference" => "CL3",
+                            "is_unitary" => false,
+                            "park_id" => 1,
+                            "category_id" => 1,
+                            "sub_category_id" => 1,
+                            "rental_price" => 300,
+                            "stock_quantity" => 5,
+                            "out_of_order_quantity" => 1,
+                            "replacement_price" => 19400,
+                            "is_hidden_on_bill" => false,
+                            "is_discountable" => false,
+                            "tags" => [
+                                [
+                                    "id" => 3,
+                                    "name" => "pro"
+                                ]
+                            ],
+                            "attributes" => [
+                                [
+                                    "id" => 3,
+                                    "name" => "Puissance",
+                                    "type" => "integer",
+                                    "unit" => "W",
+                                    "value" => 850
+                                ],
+                                [
+                                    "id" => 2,
+                                    "name" => "Couleur",
+                                    "type" => "string",
+                                    "unit" => null,
+                                    "value" => "Grise"
+                                ],
+                                [
+                                    "id" => 1,
+                                    "name" => "Poids",
+                                    "type" => "float",
+                                    "unit" => "kg",
+                                    "value" => 36.5
+                                ]
+                            ],
+                            "pivot" => [
+                                "event_id" => 1,
+                                "material_id" => 1,
+                                "id" => 1,
+                                "quantity" => 1,
+                                "quantity_returned" => 1,
+                                "quantity_broken" => 0
+                            ]
+                        ],
+                        [
+                            "id" => 2,
+                            "name" => "Processeur DBX PA2",
+                            "description" => "Système de diffusion numérique",
+                            "reference" => "DBXPA2",
+                            "is_unitary" => false,
+                            "park_id" => 1,
+                            "category_id" => 1,
+                            "sub_category_id" => 2,
+                            "rental_price" => 25.5,
+                            "stock_quantity" => 2,
+                            "out_of_order_quantity" => null,
+                            "replacement_price" => 349.9,
+                            "is_hidden_on_bill" => false,
+                            "is_discountable" => true,
+                            "tags" => [
+                                [
+                                    "id" => 3,
+                                    "name" => "pro"
+                                ]
+                            ],
+                            "attributes" => [
+                                [
+                                    "id" => 3,
+                                    "name" => "Puissance",
+                                    "type" => "integer",
+                                    "unit" => "W",
+                                    "value" => 35
+                                ],
+                                [
+                                    "id" => 1,
+                                    "name" => "Poids",
+                                    "type" => "float",
+                                    "unit" => "kg",
+                                    "value" => 2.2
+                                ]
+                            ],
+                            "pivot" => [
+                                "event_id" => 1,
+                                "material_id" => 2,
+                                "id" => 2,
+                                "quantity" => 1,
+                                "quantity_returned" => 1,
+                                "quantity_broken" => 0
+                            ]
+                        ],
+                        [
+                            "id" => 4,
+                            "name" => "Showtec SDS-6",
+                            "description" => "Console DMX (jeu d'orgue) Showtec 6 canaux",
+                            "reference" => "SDS-6-01",
+                            "is_unitary" => false,
+                            "park_id" => 1,
+                            "category_id" => 2,
+                            "sub_category_id" => 4,
+                            "rental_price" => 15.95,
+                            "stock_quantity" => 2,
+                            "out_of_order_quantity" => null,
+                            "replacement_price" => 59,
+                            "is_hidden_on_bill" => false,
+                            "is_discountable" => true,
+                            "tags" => [
+                            ],
+                            "attributes" => [
+                                [
+                                    "id" => 4,
+                                    "name" => "Conforme",
+                                    "type" => "boolean",
+                                    "unit" => null,
+                                    "value" => true
+                                ],
+                                [
+                                    "id" => 3,
+                                    "name" => "Puissance",
+                                    "type" => "integer",
+                                    "unit" => "W",
+                                    "value" => 60
+                                ],
+                                [
+                                    "id" => 1,
+                                    "name" => "Poids",
+                                    "type" => "float",
+                                    "unit" => "kg",
+                                    "value" => 3.15
+                                ]
+                            ],
+                            "pivot" => [
+                                "event_id" => 1,
+                                "material_id" => 4,
+                                "id" => 3,
+                                "quantity" => 1,
+                                "quantity_returned" => 1,
+                                "quantity_broken" => 1
+                            ]
+                        ]
+                    ],
+                    "has_missing_materials" => null,
+                    "has_not_returned_materials" => false,
+                    "parks" => [
+                        1
+                    ]
+                ],
+                [
+                    "id" => 2,
+                    "user_id" => 1,
+                    "title" => "Second événement",
+                    "description" => null,
+                    "reference" => null,
+                    "start_date" => "2018-12-18 00:00:00",
+                    "end_date" => "2018-12-19 23:59:59",
+                    "is_confirmed" => false,
+                    "is_archived" => false,
+                    "location" => "Lyon",
+                    "is_billable" => true,
+                    "is_return_inventory_done" => true,
+                    "created_at" => null,
+                    "updated_at" => null,
+                    "deleted_at" => null,
+                    "beneficiaries" => [
+                        [
+                            "id" => 3,
+                            "first_name" => "Client",
+                            "last_name" => "Benef",
+                            "full_name" => "Client Benef",
+                            "country" => null,
+                            "company" => null,
+                            "pivot" => [
+                                "event_id" => "2",
+                                "person_id" => "3"
+                            ]
+                        ]
+                    ],
+                    "technicians" => [
+                    ],
+                    "materials" => [
+                        [
+                            "id" => 1,
+                            "name" => "Console Yamaha CL3",
+                            "description" => "Console numérique 64 entrées / 8 sorties + Master + Sub",
+                            "reference" => "CL3",
+                            "is_unitary" => false,
+                            "park_id" => 1,
+                            "category_id" => 1,
+                            "sub_category_id" => 1,
+                            "rental_price" => 300,
+                            "stock_quantity" => 5,
+                            "out_of_order_quantity" => 1,
+                            "replacement_price" => 19400,
+                            "is_hidden_on_bill" => false,
+                            "is_discountable" => false,
+                            "tags" => [
+                                [
+                                    "id" => 3,
+                                    "name" => "pro"
+                                ]
+                            ],
+                            "attributes" => [
+                                [
+                                    "id" => 3,
+                                    "name" => "Puissance",
+                                    "type" => "integer",
+                                    "unit" => "W",
+                                    "value" => 850
+                                ],
+                                [
+                                    "id" => 2,
+                                    "name" => "Couleur",
+                                    "type" => "string",
+                                    "unit" => null,
+                                    "value" => "Grise"
+                                ],
+                                [
+                                    "id" => 1,
+                                    "name" => "Poids",
+                                    "type" => "float",
+                                    "unit" => "kg",
+                                    "value" => 36.5
+                                ]
+                            ],
+                            "pivot" => [
+                                "event_id" => 2,
+                                "material_id" => 1,
+                                "id" => 4,
+                                "quantity" => 3,
+                                "quantity_returned" => 2,
+                                "quantity_broken" => 0
+                            ]
+                        ],
+                        [
+                            "id" => 2,
+                            "name" => "Processeur DBX PA2",
+                            "description" => "Système de diffusion numérique",
+                            "reference" => "DBXPA2",
+                            "is_unitary" => false,
+                            "park_id" => 1,
+                            "category_id" => 1,
+                            "sub_category_id" => 2,
+                            "rental_price" => 25.5,
+                            "stock_quantity" => 2,
+                            "out_of_order_quantity" => null,
+                            "replacement_price" => 349.9,
+                            "is_hidden_on_bill" => false,
+                            "is_discountable" => true,
+                            "tags" => [
+                                [
+                                    "id" => 3,
+                                    "name" => "pro"
+                                ]
+                            ],
+                            "attributes" => [
+                                [
+                                    "id" => 3,
+                                    "name" => "Puissance",
+                                    "type" => "integer",
+                                    "unit" => "W",
+                                    "value" => 35
+                                ],
+                                [
+                                    "id" => 1,
+                                    "name" => "Poids",
+                                    "type" => "float",
+                                    "unit" => "kg",
+                                    "value" => 2.2
+                                ]
+                            ],
+                            "pivot" => [
+                                "event_id" => 2,
+                                "material_id" => 2,
+                                "id" => 5,
+                                "quantity" => 2,
+                                "quantity_returned" => 2,
+                                "quantity_broken" => 0
+                            ]
+                        ]
+                    ],
+                    "has_missing_materials" => null,
+                    "has_not_returned_materials" => true,
+                    "parks" => [
+                        1
+                    ]
+                ]
+            ]
+        ]);
+    }
 }

--- a/server/tests/endpoints/EventsTest.php
+++ b/server/tests/endpoints/EventsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Robert2\Tests;
 
 final class EventsTest extends ApiTestCase
@@ -1132,518 +1133,516 @@ final class EventsTest extends ApiTestCase
 
     public function testGetEventsWithMaterials()
     {
-        $this->client->get('/api/events?start=2018-01-01&end=2018-12-31&materials=true');
+        $this->client->get('/api/events?start=2018-01-01&end=2018-12-31&with-materials=true');
         $this->assertStatusCode(SUCCESS_OK);
         $this->assertResponseData([
-            "data" => [
+            'data' => [
                 [
-                    "id" => 3,
-                    "user_id" => 1,
-                    "title" => "Avant-premier événement",
-                    "description" => null,
-                    "reference" => null,
-                    "start_date" => "2018-12-15 00:00:00",
-                    "end_date" => "2018-12-16 23:59:59",
-                    "is_confirmed" => false,
-                    "is_archived" => true,
-                    "location" => "Brousse",
-                    "is_billable" => false,
-                    "is_return_inventory_done" => false,
-                    "created_at" => null,
-                    "updated_at" => null,
-                    "deleted_at" => null,
-                    "beneficiaries" => [
-                    ],
-                    "technicians" => [
-                    ],
-                    "materials" => [
+                    'id' => 3,
+                    'user_id' => 1,
+                    'title' => 'Avant-premier événement',
+                    'description' => null,
+                    'reference' => null,
+                    'start_date' => '2018-12-15 00:00:00',
+                    'end_date' => '2018-12-16 23:59:59',
+                    'is_confirmed' => false,
+                    'is_archived' => true,
+                    'location' => 'Brousse',
+                    'is_billable' => false,
+                    'is_return_inventory_done' => false,
+                    'created_at' => null,
+                    'updated_at' => null,
+                    'deleted_at' => null,
+                    'beneficiaries' => [],
+                    'technicians' => [],
+                    'materials' => [
                         [
-                            "id" => 3,
-                            "name" => "PAR64 LED",
-                            "description" => "Projecteur PAR64 à LED, avec son set de gélatines",
-                            "reference" => "PAR64LED",
-                            "is_unitary" => false,
-                            "park_id" => 1,
-                            "category_id" => 2,
-                            "sub_category_id" => 3,
-                            "rental_price" => 3.5,
-                            "stock_quantity" => 34,
-                            "out_of_order_quantity" => 4,
-                            "replacement_price" => 89,
-                            "is_hidden_on_bill" => false,
-                            "is_discountable" => true,
-                            "tags" => [
+                            'id' => 3,
+                            'name' => 'PAR64 LED',
+                            'description' => 'Projecteur PAR64 à LED, avec son set de gélatines',
+                            'reference' => 'PAR64LED',
+                            'is_unitary' => false,
+                            'park_id' => 1,
+                            'category_id' => 2,
+                            'sub_category_id' => 3,
+                            'rental_price' => 3.5,
+                            'stock_quantity' => 34,
+                            'out_of_order_quantity' => 4,
+                            'replacement_price' => 89,
+                            'is_hidden_on_bill' => false,
+                            'is_discountable' => true,
+                            'tags' => [
                                 [
-                                    "id" => 3,
-                                    "name" => "pro"
+                                    'id' => 3,
+                                    'name' => 'pro'
                                 ]
                             ],
-                            "attributes" => [
+                            'attributes' => [
                                 [
-                                    "id" => 3,
-                                    "name" => "Puissance",
-                                    "type" => "integer",
-                                    "unit" => "W",
-                                    "value" => 150
+                                    'id' => 3,
+                                    'name' => 'Puissance',
+                                    'type' => 'integer',
+                                    'unit' => 'W',
+                                    'value' => 150
                                 ],
                                 [
-                                    "id" => 1,
-                                    "name" => "Poids",
-                                    "type" => "float",
-                                    "unit" => "kg",
-                                    "value" => 0.85
+                                    'id' => 1,
+                                    'name' => 'Poids',
+                                    'type' => 'float',
+                                    'unit' => 'kg',
+                                    'value' => 0.85
                                 ]
                             ],
-                            "pivot" => [
-                                "event_id" => 3,
-                                "material_id" => 3,
-                                "id" => 6,
-                                "quantity" => 10,
-                                "quantity_returned" => 0,
-                                "quantity_broken" => 0
+                            'pivot' => [
+                                'event_id' => 3,
+                                'material_id' => 3,
+                                'id' => 6,
+                                'quantity' => 10,
+                                'quantity_returned' => 0,
+                                'quantity_broken' => 0
                             ]
                         ],
                         [
-                            "id" => 2,
-                            "name" => "Processeur DBX PA2",
-                            "description" => "Système de diffusion numérique",
-                            "reference" => "DBXPA2",
-                            "is_unitary" => false,
-                            "park_id" => 1,
-                            "category_id" => 1,
-                            "sub_category_id" => 2,
-                            "rental_price" => 25.5,
-                            "stock_quantity" => 2,
-                            "out_of_order_quantity" => null,
-                            "replacement_price" => 349.9,
-                            "is_hidden_on_bill" => false,
-                            "is_discountable" => true,
-                            "tags" => [
+                            'id' => 2,
+                            'name' => 'Processeur DBX PA2',
+                            'description' => 'Système de diffusion numérique',
+                            'reference' => 'DBXPA2',
+                            'is_unitary' => false,
+                            'park_id' => 1,
+                            'category_id' => 1,
+                            'sub_category_id' => 2,
+                            'rental_price' => 25.5,
+                            'stock_quantity' => 2,
+                            'out_of_order_quantity' => null,
+                            'replacement_price' => 349.9,
+                            'is_hidden_on_bill' => false,
+                            'is_discountable' => true,
+                            'tags' => [
                                 [
-                                    "id" => 3,
-                                    "name" => "pro"
+                                    'id' => 3,
+                                    'name' => 'pro'
                                 ]
                             ],
-                            "attributes" => [
+                            'attributes' => [
                                 [
-                                    "id" => 3,
-                                    "name" => "Puissance",
-                                    "type" => "integer",
-                                    "unit" => "W",
-                                    "value" => 35
+                                    'id' => 3,
+                                    'name' => 'Puissance',
+                                    'type' => 'integer',
+                                    'unit' => 'W',
+                                    'value' => 35
                                 ],
                                 [
-                                    "id" => 1,
-                                    "name" => "Poids",
-                                    "type" => "float",
-                                    "unit" => "kg",
-                                    "value" => 2.2
+                                    'id' => 1,
+                                    'name' => 'Poids',
+                                    'type' => 'float',
+                                    'unit' => 'kg',
+                                    'value' => 2.2
                                 ]
                             ],
-                            "pivot" => [
-                                "event_id" => 3,
-                                "material_id" => 2,
-                                "id" => 7,
-                                "quantity" => 1,
-                                "quantity_returned" => 0,
-                                "quantity_broken" => 0
+                            'pivot' => [
+                                'event_id' => 3,
+                                'material_id' => 2,
+                                'id' => 7,
+                                'quantity' => 1,
+                                'quantity_returned' => 0,
+                                'quantity_broken' => 0
                             ]
                         ],
                         [
-                            "id" => 5,
-                            "name" => "Câble XLR 10m",
-                            "description" => "Câble audio XLR 10 mètres, mâle-femelle",
-                            "reference" => "XLR10",
-                            "is_unitary" => false,
-                            "park_id" => 1,
-                            "category_id" => 1,
-                            "sub_category_id" => null,
-                            "rental_price" => 0.5,
-                            "stock_quantity" => 40,
-                            "out_of_order_quantity" => 8,
-                            "replacement_price" => 9.5,
-                            "is_hidden_on_bill" => true,
-                            "is_discountable" => true,
-                            "tags" => [
+                            'id' => 5,
+                            'name' => 'Câble XLR 10m',
+                            'description' => 'Câble audio XLR 10 mètres, mâle-femelle',
+                            'reference' => 'XLR10',
+                            'is_unitary' => false,
+                            'park_id' => 1,
+                            'category_id' => 1,
+                            'sub_category_id' => null,
+                            'rental_price' => 0.5,
+                            'stock_quantity' => 40,
+                            'out_of_order_quantity' => 8,
+                            'replacement_price' => 9.5,
+                            'is_hidden_on_bill' => true,
+                            'is_discountable' => true,
+                            'tags' => [
                             ],
-                            "attributes" => [
+                            'attributes' => [
                             ],
-                            "pivot" => [
-                                "event_id" => 3,
-                                "material_id" => 5,
-                                "id" => 8,
-                                "quantity" => 12,
-                                "quantity_returned" => 0,
-                                "quantity_broken" => 0
+                            'pivot' => [
+                                'event_id' => 3,
+                                'material_id' => 5,
+                                'id' => 8,
+                                'quantity' => 12,
+                                'quantity_returned' => 0,
+                                'quantity_broken' => 0
                             ]
                         ]
                     ],
-                    "has_missing_materials" => null,
-                    "has_not_returned_materials" => null,
-                    "parks" => [
+                    'has_missing_materials' => null,
+                    'has_not_returned_materials' => null,
+                    'parks' => [
                         1
                     ]
                 ],
                 [
-                    "id" => 1,
-                    "user_id" => 1,
-                    "title" => "Premier événement",
-                    "description" => null,
-                    "reference" => null,
-                    "start_date" => "2018-12-17 00:00:00",
-                    "end_date" => "2018-12-18 23:59:59",
-                    "is_confirmed" => false,
-                    "is_archived" => false,
-                    "location" => "Gap",
-                    "is_billable" => true,
-                    "is_return_inventory_done" => true,
-                    "created_at" => null,
-                    "updated_at" => null,
-                    "deleted_at" => null,
-                    "beneficiaries" => [
+                    'id' => 1,
+                    'user_id' => 1,
+                    'title' => 'Premier événement',
+                    'description' => null,
+                    'reference' => null,
+                    'start_date' => '2018-12-17 00:00:00',
+                    'end_date' => '2018-12-18 23:59:59',
+                    'is_confirmed' => false,
+                    'is_archived' => false,
+                    'location' => 'Gap',
+                    'is_billable' => true,
+                    'is_return_inventory_done' => true,
+                    'created_at' => null,
+                    'updated_at' => null,
+                    'deleted_at' => null,
+                    'beneficiaries' => [
                         [
-                            "id" => 3,
-                            "first_name" => "Client",
-                            "last_name" => "Benef",
-                            "full_name" => "Client Benef",
-                            "country" => null,
-                            "company" => null,
-                            "pivot" => [
-                                "event_id" => "1",
-                                "person_id" => "3"
+                            'id' => 3,
+                            'first_name' => 'Client',
+                            'last_name' => 'Benef',
+                            'full_name' => 'Client Benef',
+                            'country' => null,
+                            'company' => null,
+                            'pivot' => [
+                                'event_id' => '1',
+                                'person_id' => '3'
                             ]
                         ]
                     ],
-                    "technicians" => [
+                    'technicians' => [
                         [
-                            "id" => 1,
-                            "event_id" => 1,
-                            "technician_id" => 1,
-                            "start_time" => "2018-12-17 09:00:00",
-                            "end_time" => "2018-12-18 22:00:00",
-                            "position" => "Régisseur",
-                            "technician" => [
-                                "id" => 1,
-                                "first_name" => "Jean",
-                                "last_name" => "Fountain",
-                                "nickname" => null,
-                                "phone" => null,
-                                "full_name" => "Jean Fountain",
-                                "country" => null,
-                                "company" => null
+                            'id' => 1,
+                            'event_id' => 1,
+                            'technician_id' => 1,
+                            'start_time' => '2018-12-17 09:00:00',
+                            'end_time' => '2018-12-18 22:00:00',
+                            'position' => 'Régisseur',
+                            'technician' => [
+                                'id' => 1,
+                                'first_name' => 'Jean',
+                                'last_name' => 'Fountain',
+                                'nickname' => null,
+                                'phone' => null,
+                                'full_name' => 'Jean Fountain',
+                                'country' => null,
+                                'company' => null
                             ]
                         ],
                         [
-                            "id" => 2,
-                            "event_id" => 1,
-                            "technician_id" => 2,
-                            "start_time" => "2018-12-18 14:00:00",
-                            "end_time" => "2018-12-18 18:00:00",
-                            "position" => "Technicien plateau",
-                            "technician" => [
-                                "id" => 2,
-                                "first_name" => "Roger",
-                                "last_name" => "Rabbit",
-                                "nickname" => "Riri",
-                                "phone" => null,
-                                "full_name" => "Roger Rabbit",
-                                "country" => null,
-                                "company" => null
+                            'id' => 2,
+                            'event_id' => 1,
+                            'technician_id' => 2,
+                            'start_time' => '2018-12-18 14:00:00',
+                            'end_time' => '2018-12-18 18:00:00',
+                            'position' => 'Technicien plateau',
+                            'technician' => [
+                                'id' => 2,
+                                'first_name' => 'Roger',
+                                'last_name' => 'Rabbit',
+                                'nickname' => 'Riri',
+                                'phone' => null,
+                                'full_name' => 'Roger Rabbit',
+                                'country' => null,
+                                'company' => null
                             ]
                         ]
                     ],
-                    "materials" => [
+                    'materials' => [
                         [
-                            "id" => 1,
-                            "name" => "Console Yamaha CL3",
-                            "description" => "Console numérique 64 entrées / 8 sorties + Master + Sub",
-                            "reference" => "CL3",
-                            "is_unitary" => false,
-                            "park_id" => 1,
-                            "category_id" => 1,
-                            "sub_category_id" => 1,
-                            "rental_price" => 300,
-                            "stock_quantity" => 5,
-                            "out_of_order_quantity" => 1,
-                            "replacement_price" => 19400,
-                            "is_hidden_on_bill" => false,
-                            "is_discountable" => false,
-                            "tags" => [
+                            'id' => 1,
+                            'name' => 'Console Yamaha CL3',
+                            'description' => 'Console numérique 64 entrées / 8 sorties + Master + Sub',
+                            'reference' => 'CL3',
+                            'is_unitary' => false,
+                            'park_id' => 1,
+                            'category_id' => 1,
+                            'sub_category_id' => 1,
+                            'rental_price' => 300,
+                            'stock_quantity' => 5,
+                            'out_of_order_quantity' => 1,
+                            'replacement_price' => 19400,
+                            'is_hidden_on_bill' => false,
+                            'is_discountable' => false,
+                            'tags' => [
                                 [
-                                    "id" => 3,
-                                    "name" => "pro"
+                                    'id' => 3,
+                                    'name' => 'pro'
                                 ]
                             ],
-                            "attributes" => [
+                            'attributes' => [
                                 [
-                                    "id" => 3,
-                                    "name" => "Puissance",
-                                    "type" => "integer",
-                                    "unit" => "W",
-                                    "value" => 850
+                                    'id' => 3,
+                                    'name' => 'Puissance',
+                                    'type' => 'integer',
+                                    'unit' => 'W',
+                                    'value' => 850
                                 ],
                                 [
-                                    "id" => 2,
-                                    "name" => "Couleur",
-                                    "type" => "string",
-                                    "unit" => null,
-                                    "value" => "Grise"
+                                    'id' => 2,
+                                    'name' => 'Couleur',
+                                    'type' => 'string',
+                                    'unit' => null,
+                                    'value' => 'Grise'
                                 ],
                                 [
-                                    "id" => 1,
-                                    "name" => "Poids",
-                                    "type" => "float",
-                                    "unit" => "kg",
-                                    "value" => 36.5
+                                    'id' => 1,
+                                    'name' => 'Poids',
+                                    'type' => 'float',
+                                    'unit' => 'kg',
+                                    'value' => 36.5
                                 ]
                             ],
-                            "pivot" => [
-                                "event_id" => 1,
-                                "material_id" => 1,
-                                "id" => 1,
-                                "quantity" => 1,
-                                "quantity_returned" => 1,
-                                "quantity_broken" => 0
+                            'pivot' => [
+                                'event_id' => 1,
+                                'material_id' => 1,
+                                'id' => 1,
+                                'quantity' => 1,
+                                'quantity_returned' => 1,
+                                'quantity_broken' => 0
                             ]
                         ],
                         [
-                            "id" => 2,
-                            "name" => "Processeur DBX PA2",
-                            "description" => "Système de diffusion numérique",
-                            "reference" => "DBXPA2",
-                            "is_unitary" => false,
-                            "park_id" => 1,
-                            "category_id" => 1,
-                            "sub_category_id" => 2,
-                            "rental_price" => 25.5,
-                            "stock_quantity" => 2,
-                            "out_of_order_quantity" => null,
-                            "replacement_price" => 349.9,
-                            "is_hidden_on_bill" => false,
-                            "is_discountable" => true,
-                            "tags" => [
+                            'id' => 2,
+                            'name' => 'Processeur DBX PA2',
+                            'description' => 'Système de diffusion numérique',
+                            'reference' => 'DBXPA2',
+                            'is_unitary' => false,
+                            'park_id' => 1,
+                            'category_id' => 1,
+                            'sub_category_id' => 2,
+                            'rental_price' => 25.5,
+                            'stock_quantity' => 2,
+                            'out_of_order_quantity' => null,
+                            'replacement_price' => 349.9,
+                            'is_hidden_on_bill' => false,
+                            'is_discountable' => true,
+                            'tags' => [
                                 [
-                                    "id" => 3,
-                                    "name" => "pro"
+                                    'id' => 3,
+                                    'name' => 'pro'
                                 ]
                             ],
-                            "attributes" => [
+                            'attributes' => [
                                 [
-                                    "id" => 3,
-                                    "name" => "Puissance",
-                                    "type" => "integer",
-                                    "unit" => "W",
-                                    "value" => 35
+                                    'id' => 3,
+                                    'name' => 'Puissance',
+                                    'type' => 'integer',
+                                    'unit' => 'W',
+                                    'value' => 35
                                 ],
                                 [
-                                    "id" => 1,
-                                    "name" => "Poids",
-                                    "type" => "float",
-                                    "unit" => "kg",
-                                    "value" => 2.2
+                                    'id' => 1,
+                                    'name' => 'Poids',
+                                    'type' => 'float',
+                                    'unit' => 'kg',
+                                    'value' => 2.2
                                 ]
                             ],
-                            "pivot" => [
-                                "event_id" => 1,
-                                "material_id" => 2,
-                                "id" => 2,
-                                "quantity" => 1,
-                                "quantity_returned" => 1,
-                                "quantity_broken" => 0
+                            'pivot' => [
+                                'event_id' => 1,
+                                'material_id' => 2,
+                                'id' => 2,
+                                'quantity' => 1,
+                                'quantity_returned' => 1,
+                                'quantity_broken' => 0
                             ]
                         ],
                         [
-                            "id" => 4,
-                            "name" => "Showtec SDS-6",
-                            "description" => "Console DMX (jeu d'orgue) Showtec 6 canaux",
-                            "reference" => "SDS-6-01",
-                            "is_unitary" => false,
-                            "park_id" => 1,
-                            "category_id" => 2,
-                            "sub_category_id" => 4,
-                            "rental_price" => 15.95,
-                            "stock_quantity" => 2,
-                            "out_of_order_quantity" => null,
-                            "replacement_price" => 59,
-                            "is_hidden_on_bill" => false,
-                            "is_discountable" => true,
-                            "tags" => [
+                            'id' => 4,
+                            'name' => 'Showtec SDS-6',
+                            'description' => "Console DMX (jeu d'orgue) Showtec 6 canaux",
+                            'reference' => 'SDS-6-01',
+                            'is_unitary' => false,
+                            'park_id' => 1,
+                            'category_id' => 2,
+                            'sub_category_id' => 4,
+                            'rental_price' => 15.95,
+                            'stock_quantity' => 2,
+                            'out_of_order_quantity' => null,
+                            'replacement_price' => 59,
+                            'is_hidden_on_bill' => false,
+                            'is_discountable' => true,
+                            'tags' => [
                             ],
-                            "attributes" => [
+                            'attributes' => [
                                 [
-                                    "id" => 4,
-                                    "name" => "Conforme",
-                                    "type" => "boolean",
-                                    "unit" => null,
-                                    "value" => true
+                                    'id' => 4,
+                                    'name' => 'Conforme',
+                                    'type' => 'boolean',
+                                    'unit' => null,
+                                    'value' => true
                                 ],
                                 [
-                                    "id" => 3,
-                                    "name" => "Puissance",
-                                    "type" => "integer",
-                                    "unit" => "W",
-                                    "value" => 60
+                                    'id' => 3,
+                                    'name' => 'Puissance',
+                                    'type' => 'integer',
+                                    'unit' => 'W',
+                                    'value' => 60
                                 ],
                                 [
-                                    "id" => 1,
-                                    "name" => "Poids",
-                                    "type" => "float",
-                                    "unit" => "kg",
-                                    "value" => 3.15
+                                    'id' => 1,
+                                    'name' => 'Poids',
+                                    'type' => 'float',
+                                    'unit' => 'kg',
+                                    'value' => 3.15
                                 ]
                             ],
-                            "pivot" => [
-                                "event_id" => 1,
-                                "material_id" => 4,
-                                "id" => 3,
-                                "quantity" => 1,
-                                "quantity_returned" => 1,
-                                "quantity_broken" => 1
+                            'pivot' => [
+                                'event_id' => 1,
+                                'material_id' => 4,
+                                'id' => 3,
+                                'quantity' => 1,
+                                'quantity_returned' => 1,
+                                'quantity_broken' => 1
                             ]
                         ]
                     ],
-                    "has_missing_materials" => null,
-                    "has_not_returned_materials" => false,
-                    "parks" => [
+                    'has_missing_materials' => null,
+                    'has_not_returned_materials' => false,
+                    'parks' => [
                         1
                     ]
                 ],
                 [
-                    "id" => 2,
-                    "user_id" => 1,
-                    "title" => "Second événement",
-                    "description" => null,
-                    "reference" => null,
-                    "start_date" => "2018-12-18 00:00:00",
-                    "end_date" => "2018-12-19 23:59:59",
-                    "is_confirmed" => false,
-                    "is_archived" => false,
-                    "location" => "Lyon",
-                    "is_billable" => true,
-                    "is_return_inventory_done" => true,
-                    "created_at" => null,
-                    "updated_at" => null,
-                    "deleted_at" => null,
-                    "beneficiaries" => [
+                    'id' => 2,
+                    'user_id' => 1,
+                    'title' => 'Second événement',
+                    'description' => null,
+                    'reference' => null,
+                    'start_date' => '2018-12-18 00:00:00',
+                    'end_date' => '2018-12-19 23:59:59',
+                    'is_confirmed' => false,
+                    'is_archived' => false,
+                    'location' => 'Lyon',
+                    'is_billable' => true,
+                    'is_return_inventory_done' => true,
+                    'created_at' => null,
+                    'updated_at' => null,
+                    'deleted_at' => null,
+                    'beneficiaries' => [
                         [
-                            "id" => 3,
-                            "first_name" => "Client",
-                            "last_name" => "Benef",
-                            "full_name" => "Client Benef",
-                            "country" => null,
-                            "company" => null,
-                            "pivot" => [
-                                "event_id" => "2",
-                                "person_id" => "3"
+                            'id' => 3,
+                            'first_name' => 'Client',
+                            'last_name' => 'Benef',
+                            'full_name' => 'Client Benef',
+                            'country' => null,
+                            'company' => null,
+                            'pivot' => [
+                                'event_id' => '2',
+                                'person_id' => '3'
                             ]
                         ]
                     ],
-                    "technicians" => [
+                    'technicians' => [
                     ],
-                    "materials" => [
+                    'materials' => [
                         [
-                            "id" => 1,
-                            "name" => "Console Yamaha CL3",
-                            "description" => "Console numérique 64 entrées / 8 sorties + Master + Sub",
-                            "reference" => "CL3",
-                            "is_unitary" => false,
-                            "park_id" => 1,
-                            "category_id" => 1,
-                            "sub_category_id" => 1,
-                            "rental_price" => 300,
-                            "stock_quantity" => 5,
-                            "out_of_order_quantity" => 1,
-                            "replacement_price" => 19400,
-                            "is_hidden_on_bill" => false,
-                            "is_discountable" => false,
-                            "tags" => [
+                            'id' => 1,
+                            'name' => 'Console Yamaha CL3',
+                            'description' => 'Console numérique 64 entrées / 8 sorties + Master + Sub',
+                            'reference' => 'CL3',
+                            'is_unitary' => false,
+                            'park_id' => 1,
+                            'category_id' => 1,
+                            'sub_category_id' => 1,
+                            'rental_price' => 300,
+                            'stock_quantity' => 5,
+                            'out_of_order_quantity' => 1,
+                            'replacement_price' => 19400,
+                            'is_hidden_on_bill' => false,
+                            'is_discountable' => false,
+                            'tags' => [
                                 [
-                                    "id" => 3,
-                                    "name" => "pro"
+                                    'id' => 3,
+                                    'name' => 'pro'
                                 ]
                             ],
-                            "attributes" => [
+                            'attributes' => [
                                 [
-                                    "id" => 3,
-                                    "name" => "Puissance",
-                                    "type" => "integer",
-                                    "unit" => "W",
-                                    "value" => 850
+                                    'id' => 3,
+                                    'name' => 'Puissance',
+                                    'type' => 'integer',
+                                    'unit' => 'W',
+                                    'value' => 850
                                 ],
                                 [
-                                    "id" => 2,
-                                    "name" => "Couleur",
-                                    "type" => "string",
-                                    "unit" => null,
-                                    "value" => "Grise"
+                                    'id' => 2,
+                                    'name' => 'Couleur',
+                                    'type' => 'string',
+                                    'unit' => null,
+                                    'value' => 'Grise'
                                 ],
                                 [
-                                    "id" => 1,
-                                    "name" => "Poids",
-                                    "type" => "float",
-                                    "unit" => "kg",
-                                    "value" => 36.5
+                                    'id' => 1,
+                                    'name' => 'Poids',
+                                    'type' => 'float',
+                                    'unit' => 'kg',
+                                    'value' => 36.5
                                 ]
                             ],
-                            "pivot" => [
-                                "event_id" => 2,
-                                "material_id" => 1,
-                                "id" => 4,
-                                "quantity" => 3,
-                                "quantity_returned" => 2,
-                                "quantity_broken" => 0
+                            'pivot' => [
+                                'event_id' => 2,
+                                'material_id' => 1,
+                                'id' => 4,
+                                'quantity' => 3,
+                                'quantity_returned' => 2,
+                                'quantity_broken' => 0
                             ]
                         ],
                         [
-                            "id" => 2,
-                            "name" => "Processeur DBX PA2",
-                            "description" => "Système de diffusion numérique",
-                            "reference" => "DBXPA2",
-                            "is_unitary" => false,
-                            "park_id" => 1,
-                            "category_id" => 1,
-                            "sub_category_id" => 2,
-                            "rental_price" => 25.5,
-                            "stock_quantity" => 2,
-                            "out_of_order_quantity" => null,
-                            "replacement_price" => 349.9,
-                            "is_hidden_on_bill" => false,
-                            "is_discountable" => true,
-                            "tags" => [
+                            'id' => 2,
+                            'name' => 'Processeur DBX PA2',
+                            'description' => 'Système de diffusion numérique',
+                            'reference' => 'DBXPA2',
+                            'is_unitary' => false,
+                            'park_id' => 1,
+                            'category_id' => 1,
+                            'sub_category_id' => 2,
+                            'rental_price' => 25.5,
+                            'stock_quantity' => 2,
+                            'out_of_order_quantity' => null,
+                            'replacement_price' => 349.9,
+                            'is_hidden_on_bill' => false,
+                            'is_discountable' => true,
+                            'tags' => [
                                 [
-                                    "id" => 3,
-                                    "name" => "pro"
+                                    'id' => 3,
+                                    'name' => 'pro'
                                 ]
                             ],
-                            "attributes" => [
+                            'attributes' => [
                                 [
-                                    "id" => 3,
-                                    "name" => "Puissance",
-                                    "type" => "integer",
-                                    "unit" => "W",
-                                    "value" => 35
+                                    'id' => 3,
+                                    'name' => 'Puissance',
+                                    'type' => 'integer',
+                                    'unit' => 'W',
+                                    'value' => 35
                                 ],
                                 [
-                                    "id" => 1,
-                                    "name" => "Poids",
-                                    "type" => "float",
-                                    "unit" => "kg",
-                                    "value" => 2.2
+                                    'id' => 1,
+                                    'name' => 'Poids',
+                                    'type' => 'float',
+                                    'unit' => 'kg',
+                                    'value' => 2.2
                                 ]
                             ],
-                            "pivot" => [
-                                "event_id" => 2,
-                                "material_id" => 2,
-                                "id" => 5,
-                                "quantity" => 2,
-                                "quantity_returned" => 2,
-                                "quantity_broken" => 0
+                            'pivot' => [
+                                'event_id' => 2,
+                                'material_id' => 2,
+                                'id' => 5,
+                                'quantity' => 2,
+                                'quantity_returned' => 2,
+                                'quantity_broken' => 0
                             ]
                         ]
                     ],
-                    "has_missing_materials" => null,
-                    "has_not_returned_materials" => true,
-                    "parks" => [
+                    'has_missing_materials' => null,
+                    'has_not_returned_materials' => true,
+                    'parks' => [
                         1
                     ]
                 ]

--- a/server/tests/endpoints/EventsTest.php
+++ b/server/tests/endpoints/EventsTest.php
@@ -1157,6 +1157,34 @@ final class EventsTest extends ApiTestCase
                     'technicians' => [],
                     'materials' => [
                         [
+                            'id' => 5,
+                            'name' => 'Câble XLR 10m',
+                            'description' => 'Câble audio XLR 10 mètres, mâle-femelle',
+                            'reference' => 'XLR10',
+                            'is_unitary' => false,
+                            'park_id' => 1,
+                            'category_id' => 1,
+                            'sub_category_id' => null,
+                            'rental_price' => 0.5,
+                            'stock_quantity' => 40,
+                            'out_of_order_quantity' => 8,
+                            'replacement_price' => 9.5,
+                            'is_hidden_on_bill' => true,
+                            'is_discountable' => true,
+                            'tags' => [
+                            ],
+                            'attributes' => [
+                            ],
+                            'pivot' => [
+                                'event_id' => 3,
+                                'material_id' => 5,
+                                'id' => 8,
+                                'quantity' => 12,
+                                'quantity_returned' => 0,
+                                'quantity_broken' => 0
+                            ]
+                        ],
+                        [
                             'id' => 3,
                             'name' => 'PAR64 LED',
                             'description' => 'Projecteur PAR64 à LED, avec son set de gélatines',
@@ -1248,40 +1276,10 @@ final class EventsTest extends ApiTestCase
                                 'quantity_broken' => 0
                             ]
                         ],
-                        [
-                            'id' => 5,
-                            'name' => 'Câble XLR 10m',
-                            'description' => 'Câble audio XLR 10 mètres, mâle-femelle',
-                            'reference' => 'XLR10',
-                            'is_unitary' => false,
-                            'park_id' => 1,
-                            'category_id' => 1,
-                            'sub_category_id' => null,
-                            'rental_price' => 0.5,
-                            'stock_quantity' => 40,
-                            'out_of_order_quantity' => 8,
-                            'replacement_price' => 9.5,
-                            'is_hidden_on_bill' => true,
-                            'is_discountable' => true,
-                            'tags' => [
-                            ],
-                            'attributes' => [
-                            ],
-                            'pivot' => [
-                                'event_id' => 3,
-                                'material_id' => 5,
-                                'id' => 8,
-                                'quantity' => 12,
-                                'quantity_returned' => 0,
-                                'quantity_broken' => 0
-                            ]
-                        ]
                     ],
                     'has_missing_materials' => null,
                     'has_not_returned_materials' => null,
-                    'parks' => [
-                        1
-                    ]
+                    'parks' => [1],
                 ],
                 [
                     'id' => 1,
@@ -1503,9 +1501,7 @@ final class EventsTest extends ApiTestCase
                     ],
                     'has_missing_materials' => null,
                     'has_not_returned_materials' => false,
-                    'parks' => [
-                        1
-                    ]
+                    'parks' => [1],
                 ],
                 [
                     'id' => 2,
@@ -1537,8 +1533,7 @@ final class EventsTest extends ApiTestCase
                             ]
                         ]
                     ],
-                    'technicians' => [
-                    ],
+                    'technicians' => [],
                     'materials' => [
                         [
                             'id' => 1,
@@ -1642,11 +1637,9 @@ final class EventsTest extends ApiTestCase
                     ],
                     'has_missing_materials' => null,
                     'has_not_returned_materials' => true,
-                    'parks' => [
-                        1
-                    ]
-                ]
-            ]
+                    'parks' => [1],
+                ],
+            ],
         ]);
     }
 }

--- a/server/tests/endpoints/MaterialsTest.php
+++ b/server/tests/endpoints/MaterialsTest.php
@@ -1071,4 +1071,305 @@ final class MaterialsTest extends ApiTestCase
         $this->assertStatusCode(200);
         $this->assertTrue($responseStream->isReadable());
     }
+
+    public function testGetMaterialsWithEvents()
+    {
+        $this->client->get('/api/materials?events=true');
+        $this->assertStatusCode(SUCCESS_OK);
+        $this->assertResponseData([
+            "pagination" => [
+                "current_page" => 1,
+                "first_page_url" => "/api/materials?events=true&page=1",
+                "from" => 1,
+                "last_page" => 1,
+                "last_page_url" => "/api/materials?events=true&page=1",
+                "next_page_url" => null,
+                "path" => "/api/materials",
+                "per_page" => 100,
+                "prev_page_url" => null,
+                "to" => 7,
+                "total" => 7
+            ],
+            "data" => [
+                [
+                    "id" => 6,
+                    "name" => "Behringer X Air XR18",
+                    "description" => "Mélangeur numérique 18 canaux",
+                    "reference" => "XR18",
+                    "is_unitary" => false,
+                    "park_id" => 1,
+                    "category_id" => 1,
+                    "sub_category_id" => 1,
+                    "rental_price" => 49.99,
+                    "stock_quantity" => 0,
+                    "out_of_order_quantity" => 0,
+                    "replacement_price" => 419,
+                    "is_hidden_on_bill" => false,
+                    "is_discountable" => false,
+                    "picture" => null,
+                    "note" => null,
+                    "created_at" => null,
+                    "updated_at" => null,
+                    "deleted_at" => null,
+                    "tags" => [
+                    ],
+                    "attributes" => [
+                        [
+                            "id" => 5,
+                            "name" => "Date d'achat",
+                            "type" => "date",
+                            "unit" => null,
+                            "value" => "2021-01-28"
+                        ]
+                    ],
+                    "events" => [
+                    ]
+                ],
+                [
+                    "id" => 5,
+                    "name" => "Câble XLR 10m",
+                    "description" => "Câble audio XLR 10 mètres, mâle-femelle",
+                    "reference" => "XLR10",
+                    "is_unitary" => false,
+                    "park_id" => 1,
+                    "category_id" => 1,
+                    "sub_category_id" => null,
+                    "rental_price" => 0.5,
+                    "stock_quantity" => 40,
+                    "out_of_order_quantity" => 8,
+                    "replacement_price" => 9.5,
+                    "is_hidden_on_bill" => true,
+                    "is_discountable" => true,
+                    "picture" => null,
+                    "note" => null,
+                    "created_at" => null,
+                    "updated_at" => null,
+                    "deleted_at" => null,
+                    "tags" => [
+                    ],
+                    "attributes" => [
+                    ],
+                    "events" => [
+                    ]
+                ],
+                [
+                    "id" => 1,
+                    "name" => "Console Yamaha CL3",
+                    "description" => "Console numérique 64 entrées / 8 sorties + Master + Sub",
+                    "reference" => "CL3",
+                    "is_unitary" => false,
+                    "park_id" => 1,
+                    "category_id" => 1,
+                    "sub_category_id" => 1,
+                    "rental_price" => 300,
+                    "stock_quantity" => 5,
+                    "out_of_order_quantity" => 1,
+                    "replacement_price" => 19400,
+                    "is_hidden_on_bill" => false,
+                    "is_discountable" => false,
+                    "picture" => "IMG-20210511-0001.jpg",
+                    "note" => null,
+                    "created_at" => null,
+                    "updated_at" => null,
+                    "deleted_at" => null,
+                    "tags" => [
+                        [
+                            "id" => 3,
+                            "name" => "pro"
+                        ]
+                    ],
+                    "attributes" => [
+                        [
+                            "id" => 3,
+                            "name" => "Puissance",
+                            "type" => "integer",
+                            "unit" => "W",
+                            "value" => 850
+                        ],
+                        [
+                            "id" => 2,
+                            "name" => "Couleur",
+                            "type" => "string",
+                            "unit" => null,
+                            "value" => "Grise"
+                        ],
+                        [
+                            "id" => 1,
+                            "name" => "Poids",
+                            "type" => "float",
+                            "unit" => "kg",
+                            "value" => 36.5
+                        ]
+                    ],
+                    "events" => [
+                    ]
+                ],
+                [
+                    "id" => 3,
+                    "name" => "PAR64 LED",
+                    "description" => "Projecteur PAR64 à LED, avec son set de gélatines",
+                    "reference" => "PAR64LED",
+                    "is_unitary" => false,
+                    "park_id" => 1,
+                    "category_id" => 2,
+                    "sub_category_id" => 3,
+                    "rental_price" => 3.5,
+                    "stock_quantity" => 34,
+                    "out_of_order_quantity" => 4,
+                    "replacement_price" => 89,
+                    "is_hidden_on_bill" => false,
+                    "is_discountable" => true,
+                    "picture" => null,
+                    "note" => "Soyez délicats avec ces projos !",
+                    "created_at" => null,
+                    "updated_at" => null,
+                    "deleted_at" => null,
+                    "tags" => [
+                        [
+                            "id" => 3,
+                            "name" => "pro"
+                        ]
+                    ],
+                    "attributes" => [
+                        [
+                            "id" => 3,
+                            "name" => "Puissance",
+                            "type" => "integer",
+                            "unit" => "W",
+                            "value" => 150
+                        ],
+                        [
+                            "id" => 1,
+                            "name" => "Poids",
+                            "type" => "float",
+                            "unit" => "kg",
+                            "value" => 0.85
+                        ]
+                    ],
+                    "events" => [
+                    ]
+                ],
+                [
+                    "id" => 2,
+                    "name" => "Processeur DBX PA2",
+                    "description" => "Système de diffusion numérique",
+                    "reference" => "DBXPA2",
+                    "is_unitary" => false,
+                    "park_id" => 1,
+                    "category_id" => 1,
+                    "sub_category_id" => 2,
+                    "rental_price" => 25.5,
+                    "stock_quantity" => 2,
+                    "out_of_order_quantity" => null,
+                    "replacement_price" => 349.9,
+                    "is_hidden_on_bill" => false,
+                    "is_discountable" => true,
+                    "picture" => null,
+                    "note" => null,
+                    "created_at" => null,
+                    "updated_at" => null,
+                    "deleted_at" => null,
+                    "tags" => [
+                        [
+                            "id" => 3,
+                            "name" => "pro"
+                        ]
+                    ],
+                    "attributes" => [
+                        [
+                            "id" => 3,
+                            "name" => "Puissance",
+                            "type" => "integer",
+                            "unit" => "W",
+                            "value" => 35
+                        ],
+                        [
+                            "id" => 1,
+                            "name" => "Poids",
+                            "type" => "float",
+                            "unit" => "kg",
+                            "value" => 2.2
+                        ]
+                    ],
+                    "events" => [
+                    ]
+                ],
+                [
+                    "id" => 4,
+                    "name" => "Showtec SDS-6",
+                    "description" => "Console DMX (jeu d'orgue) Showtec 6 canaux",
+                    "reference" => "SDS-6-01",
+                    "is_unitary" => false,
+                    "park_id" => 1,
+                    "category_id" => 2,
+                    "sub_category_id" => 4,
+                    "rental_price" => 15.95,
+                    "stock_quantity" => 2,
+                    "out_of_order_quantity" => null,
+                    "replacement_price" => 59,
+                    "is_hidden_on_bill" => false,
+                    "is_discountable" => true,
+                    "picture" => null,
+                    "note" => null,
+                    "created_at" => null,
+                    "updated_at" => null,
+                    "deleted_at" => null,
+                    "tags" => [
+                    ],
+                    "attributes" => [
+                        [
+                            "id" => 4,
+                            "name" => "Conforme",
+                            "type" => "boolean",
+                            "unit" => null,
+                            "value" => true
+                        ],
+                        [
+                            "id" => 3,
+                            "name" => "Puissance",
+                            "type" => "integer",
+                            "unit" => "W",
+                            "value" => 60
+                        ],
+                        [
+                            "id" => 1,
+                            "name" => "Poids",
+                            "type" => "float",
+                            "unit" => "kg",
+                            "value" => 3.15
+                        ]
+                    ],
+                    "events" => [
+                    ]
+                ],
+                [
+                    "id" => 7,
+                    "name" => "Volkswagen Transporter",
+                    "description" => "Volume utile : 9.3 m3",
+                    "reference" => "Transporter",
+                    "is_unitary" => false,
+                    "park_id" => 1,
+                    "category_id" => 3,
+                    "sub_category_id" => null,
+                    "rental_price" => 300,
+                    "stock_quantity" => 0,
+                    "out_of_order_quantity" => 0,
+                    "replacement_price" => 32000,
+                    "is_hidden_on_bill" => false,
+                    "is_discountable" => false,
+                    "picture" => null,
+                    "note" => null,
+                    "created_at" => null,
+                    "updated_at" => null,
+                    "deleted_at" => null,
+                    "tags" => [
+                    ],
+                    "attributes" => [
+                    ],
+                    "events" => [
+                    ]
+                ]
+            ]
+        ]);
+    }
 }

--- a/server/tests/endpoints/MaterialsTest.php
+++ b/server/tests/endpoints/MaterialsTest.php
@@ -1074,300 +1074,289 @@ final class MaterialsTest extends ApiTestCase
 
     public function testGetMaterialsWithEvents()
     {
-        $this->client->get('/api/materials?events=true');
+        $this->client->get('/api/materials?with-events=true');
         $this->assertStatusCode(SUCCESS_OK);
         $this->assertResponseData([
-            "pagination" => [
-                "current_page" => 1,
-                "first_page_url" => "/api/materials?events=true&page=1",
-                "from" => 1,
-                "last_page" => 1,
-                "last_page_url" => "/api/materials?events=true&page=1",
-                "next_page_url" => null,
-                "path" => "/api/materials",
-                "per_page" => 100,
-                "prev_page_url" => null,
-                "to" => 7,
-                "total" => 7
+            'pagination' => [
+                'current_page' => 1,
+                'first_page_url' => '/api/materials?with-events=true&page=1',
+                'from' => 1,
+                'last_page' => 1,
+                'last_page_url' => '/api/materials?with-events=true&page=1',
+                'next_page_url' => null,
+                'path' => '/api/materials',
+                'per_page' => 100,
+                'prev_page_url' => null,
+                'to' => 7,
+                'total' => 7
             ],
-            "data" => [
+            'data' => [
                 [
-                    "id" => 6,
-                    "name" => "Behringer X Air XR18",
-                    "description" => "Mélangeur numérique 18 canaux",
-                    "reference" => "XR18",
-                    "is_unitary" => false,
-                    "park_id" => 1,
-                    "category_id" => 1,
-                    "sub_category_id" => 1,
-                    "rental_price" => 49.99,
-                    "stock_quantity" => 0,
-                    "out_of_order_quantity" => 0,
-                    "replacement_price" => 419,
-                    "is_hidden_on_bill" => false,
-                    "is_discountable" => false,
-                    "picture" => null,
-                    "note" => null,
-                    "created_at" => null,
-                    "updated_at" => null,
-                    "deleted_at" => null,
-                    "tags" => [
+                    'id' => 6,
+                    'name' => 'Behringer X Air XR18',
+                    'description' => 'Mélangeur numérique 18 canaux',
+                    'reference' => 'XR18',
+                    'is_unitary' => false,
+                    'park_id' => 1,
+                    'category_id' => 1,
+                    'sub_category_id' => 1,
+                    'rental_price' => 49.99,
+                    'stock_quantity' => 0,
+                    'out_of_order_quantity' => 0,
+                    'replacement_price' => 419,
+                    'is_hidden_on_bill' => false,
+                    'is_discountable' => false,
+                    'picture' => null,
+                    'note' => null,
+                    'created_at' => null,
+                    'updated_at' => null,
+                    'deleted_at' => null,
+                    'tags' => [
                     ],
-                    "attributes" => [
+                    'attributes' => [
                         [
-                            "id" => 5,
-                            "name" => "Date d'achat",
-                            "type" => "date",
-                            "unit" => null,
-                            "value" => "2021-01-28"
+                            'id' => 5,
+                            'name' => 'Date d\'achat',
+                            'type' => 'date',
+                            'unit' => null,
+                            'value' => '2021-01-28'
                         ]
                     ],
-                    "events" => [
-                    ]
+                    'events' => []
                 ],
                 [
-                    "id" => 5,
-                    "name" => "Câble XLR 10m",
-                    "description" => "Câble audio XLR 10 mètres, mâle-femelle",
-                    "reference" => "XLR10",
-                    "is_unitary" => false,
-                    "park_id" => 1,
-                    "category_id" => 1,
-                    "sub_category_id" => null,
-                    "rental_price" => 0.5,
-                    "stock_quantity" => 40,
-                    "out_of_order_quantity" => 8,
-                    "replacement_price" => 9.5,
-                    "is_hidden_on_bill" => true,
-                    "is_discountable" => true,
-                    "picture" => null,
-                    "note" => null,
-                    "created_at" => null,
-                    "updated_at" => null,
-                    "deleted_at" => null,
-                    "tags" => [
-                    ],
-                    "attributes" => [
-                    ],
-                    "events" => [
-                    ]
+                    'id' => 5,
+                    'name' => 'Câble XLR 10m',
+                    'description' => 'Câble audio XLR 10 mètres, mâle-femelle',
+                    'reference' => 'XLR10',
+                    'is_unitary' => false,
+                    'park_id' => 1,
+                    'category_id' => 1,
+                    'sub_category_id' => null,
+                    'rental_price' => 0.5,
+                    'stock_quantity' => 40,
+                    'out_of_order_quantity' => 8,
+                    'replacement_price' => 9.5,
+                    'is_hidden_on_bill' => true,
+                    'is_discountable' => true,
+                    'picture' => null,
+                    'note' => null,
+                    'created_at' => null,
+                    'updated_at' => null,
+                    'deleted_at' => null,
+                    'tags' => [],
+                    'attributes' => [],
+                    'events' => []
                 ],
                 [
-                    "id" => 1,
-                    "name" => "Console Yamaha CL3",
-                    "description" => "Console numérique 64 entrées / 8 sorties + Master + Sub",
-                    "reference" => "CL3",
-                    "is_unitary" => false,
-                    "park_id" => 1,
-                    "category_id" => 1,
-                    "sub_category_id" => 1,
-                    "rental_price" => 300,
-                    "stock_quantity" => 5,
-                    "out_of_order_quantity" => 1,
-                    "replacement_price" => 19400,
-                    "is_hidden_on_bill" => false,
-                    "is_discountable" => false,
-                    "picture" => "IMG-20210511-0001.jpg",
-                    "note" => null,
-                    "created_at" => null,
-                    "updated_at" => null,
-                    "deleted_at" => null,
-                    "tags" => [
+                    'id' => 1,
+                    'name' => 'Console Yamaha CL3',
+                    'description' => 'Console numérique 64 entrées / 8 sorties + Master + Sub',
+                    'reference' => 'CL3',
+                    'is_unitary' => false,
+                    'park_id' => 1,
+                    'category_id' => 1,
+                    'sub_category_id' => 1,
+                    'rental_price' => 300,
+                    'stock_quantity' => 5,
+                    'out_of_order_quantity' => 1,
+                    'replacement_price' => 19400,
+                    'is_hidden_on_bill' => false,
+                    'is_discountable' => false,
+                    'picture' => 'IMG-20210511-0001.jpg',
+                    'note' => null,
+                    'created_at' => null,
+                    'updated_at' => null,
+                    'deleted_at' => null,
+                    'tags' => [
                         [
-                            "id" => 3,
-                            "name" => "pro"
+                            'id' => 3,
+                            'name' => 'pro'
                         ]
                     ],
-                    "attributes" => [
+                    'attributes' => [
                         [
-                            "id" => 3,
-                            "name" => "Puissance",
-                            "type" => "integer",
-                            "unit" => "W",
-                            "value" => 850
+                            'id' => 3,
+                            'name' => 'Puissance',
+                            'type' => 'integer',
+                            'unit' => 'W',
+                            'value' => 850
                         ],
                         [
-                            "id" => 2,
-                            "name" => "Couleur",
-                            "type" => "string",
-                            "unit" => null,
-                            "value" => "Grise"
+                            'id' => 2,
+                            'name' => 'Couleur',
+                            'type' => 'string',
+                            'unit' => null,
+                            'value' => 'Grise'
                         ],
                         [
-                            "id" => 1,
-                            "name" => "Poids",
-                            "type" => "float",
-                            "unit" => "kg",
-                            "value" => 36.5
+                            'id' => 1,
+                            'name' => 'Poids',
+                            'type' => 'float',
+                            'unit' => 'kg',
+                            'value' => 36.5
                         ]
                     ],
-                    "events" => [
-                    ]
+                    'events' => []
                 ],
                 [
-                    "id" => 3,
-                    "name" => "PAR64 LED",
-                    "description" => "Projecteur PAR64 à LED, avec son set de gélatines",
-                    "reference" => "PAR64LED",
-                    "is_unitary" => false,
-                    "park_id" => 1,
-                    "category_id" => 2,
-                    "sub_category_id" => 3,
-                    "rental_price" => 3.5,
-                    "stock_quantity" => 34,
-                    "out_of_order_quantity" => 4,
-                    "replacement_price" => 89,
-                    "is_hidden_on_bill" => false,
-                    "is_discountable" => true,
-                    "picture" => null,
-                    "note" => "Soyez délicats avec ces projos !",
-                    "created_at" => null,
-                    "updated_at" => null,
-                    "deleted_at" => null,
-                    "tags" => [
+                    'id' => 3,
+                    'name' => 'PAR64 LED',
+                    'description' => 'Projecteur PAR64 à LED, avec son set de gélatines',
+                    'reference' => 'PAR64LED',
+                    'is_unitary' => false,
+                    'park_id' => 1,
+                    'category_id' => 2,
+                    'sub_category_id' => 3,
+                    'rental_price' => 3.5,
+                    'stock_quantity' => 34,
+                    'out_of_order_quantity' => 4,
+                    'replacement_price' => 89,
+                    'is_hidden_on_bill' => false,
+                    'is_discountable' => true,
+                    'picture' => null,
+                    'note' => 'Soyez délicats avec ces projos !',
+                    'created_at' => null,
+                    'updated_at' => null,
+                    'deleted_at' => null,
+                    'tags' => [
                         [
-                            "id" => 3,
-                            "name" => "pro"
+                            'id' => 3,
+                            'name' => 'pro'
                         ]
                     ],
-                    "attributes" => [
+                    'attributes' => [
                         [
-                            "id" => 3,
-                            "name" => "Puissance",
-                            "type" => "integer",
-                            "unit" => "W",
-                            "value" => 150
+                            'id' => 3,
+                            'name' => 'Puissance',
+                            'type' => 'integer',
+                            'unit' => 'W',
+                            'value' => 150
                         ],
                         [
-                            "id" => 1,
-                            "name" => "Poids",
-                            "type" => "float",
-                            "unit" => "kg",
-                            "value" => 0.85
+                            'id' => 1,
+                            'name' => 'Poids',
+                            'type' => 'float',
+                            'unit' => 'kg',
+                            'value' => 0.85
                         ]
                     ],
-                    "events" => [
-                    ]
+                    'events' => []
                 ],
                 [
-                    "id" => 2,
-                    "name" => "Processeur DBX PA2",
-                    "description" => "Système de diffusion numérique",
-                    "reference" => "DBXPA2",
-                    "is_unitary" => false,
-                    "park_id" => 1,
-                    "category_id" => 1,
-                    "sub_category_id" => 2,
-                    "rental_price" => 25.5,
-                    "stock_quantity" => 2,
-                    "out_of_order_quantity" => null,
-                    "replacement_price" => 349.9,
-                    "is_hidden_on_bill" => false,
-                    "is_discountable" => true,
-                    "picture" => null,
-                    "note" => null,
-                    "created_at" => null,
-                    "updated_at" => null,
-                    "deleted_at" => null,
-                    "tags" => [
+                    'id' => 2,
+                    'name' => 'Processeur DBX PA2',
+                    'description' => 'Système de diffusion numérique',
+                    'reference' => 'DBXPA2',
+                    'is_unitary' => false,
+                    'park_id' => 1,
+                    'category_id' => 1,
+                    'sub_category_id' => 2,
+                    'rental_price' => 25.5,
+                    'stock_quantity' => 2,
+                    'out_of_order_quantity' => null,
+                    'replacement_price' => 349.9,
+                    'is_hidden_on_bill' => false,
+                    'is_discountable' => true,
+                    'picture' => null,
+                    'note' => null,
+                    'created_at' => null,
+                    'updated_at' => null,
+                    'deleted_at' => null,
+                    'tags' => [
                         [
-                            "id" => 3,
-                            "name" => "pro"
+                            'id' => 3,
+                            'name' => 'pro'
                         ]
                     ],
-                    "attributes" => [
+                    'attributes' => [
                         [
-                            "id" => 3,
-                            "name" => "Puissance",
-                            "type" => "integer",
-                            "unit" => "W",
-                            "value" => 35
+                            'id' => 3,
+                            'name' => 'Puissance',
+                            'type' => 'integer',
+                            'unit' => 'W',
+                            'value' => 35
                         ],
                         [
-                            "id" => 1,
-                            "name" => "Poids",
-                            "type" => "float",
-                            "unit" => "kg",
-                            "value" => 2.2
+                            'id' => 1,
+                            'name' => 'Poids',
+                            'type' => 'float',
+                            'unit' => 'kg',
+                            'value' => 2.2
                         ]
                     ],
-                    "events" => [
-                    ]
+                    'events' => []
                 ],
                 [
-                    "id" => 4,
-                    "name" => "Showtec SDS-6",
-                    "description" => "Console DMX (jeu d'orgue) Showtec 6 canaux",
-                    "reference" => "SDS-6-01",
-                    "is_unitary" => false,
-                    "park_id" => 1,
-                    "category_id" => 2,
-                    "sub_category_id" => 4,
-                    "rental_price" => 15.95,
-                    "stock_quantity" => 2,
-                    "out_of_order_quantity" => null,
-                    "replacement_price" => 59,
-                    "is_hidden_on_bill" => false,
-                    "is_discountable" => true,
-                    "picture" => null,
-                    "note" => null,
-                    "created_at" => null,
-                    "updated_at" => null,
-                    "deleted_at" => null,
-                    "tags" => [
+                    'id' => 4,
+                    'name' => 'Showtec SDS-6',
+                    'description' => "Console DMX (jeu d'orgue) Showtec 6 canaux",
+                    'reference' => 'SDS-6-01',
+                    'is_unitary' => false,
+                    'park_id' => 1,
+                    'category_id' => 2,
+                    'sub_category_id' => 4,
+                    'rental_price' => 15.95,
+                    'stock_quantity' => 2,
+                    'out_of_order_quantity' => null,
+                    'replacement_price' => 59,
+                    'is_hidden_on_bill' => false,
+                    'is_discountable' => true,
+                    'picture' => null,
+                    'note' => null,
+                    'created_at' => null,
+                    'updated_at' => null,
+                    'deleted_at' => null,
+                    'tags' => [
                     ],
-                    "attributes" => [
+                    'attributes' => [
                         [
-                            "id" => 4,
-                            "name" => "Conforme",
-                            "type" => "boolean",
-                            "unit" => null,
-                            "value" => true
+                            'id' => 4,
+                            'name' => 'Conforme',
+                            'type' => 'boolean',
+                            'unit' => null,
+                            'value' => true
                         ],
                         [
-                            "id" => 3,
-                            "name" => "Puissance",
-                            "type" => "integer",
-                            "unit" => "W",
-                            "value" => 60
+                            'id' => 3,
+                            'name' => 'Puissance',
+                            'type' => 'integer',
+                            'unit' => 'W',
+                            'value' => 60
                         ],
                         [
-                            "id" => 1,
-                            "name" => "Poids",
-                            "type" => "float",
-                            "unit" => "kg",
-                            "value" => 3.15
+                            'id' => 1,
+                            'name' => 'Poids',
+                            'type' => 'float',
+                            'unit' => 'kg',
+                            'value' => 3.15
                         ]
                     ],
-                    "events" => [
-                    ]
+                    'events' => []
                 ],
                 [
-                    "id" => 7,
-                    "name" => "Volkswagen Transporter",
-                    "description" => "Volume utile : 9.3 m3",
-                    "reference" => "Transporter",
-                    "is_unitary" => false,
-                    "park_id" => 1,
-                    "category_id" => 3,
-                    "sub_category_id" => null,
-                    "rental_price" => 300,
-                    "stock_quantity" => 0,
-                    "out_of_order_quantity" => 0,
-                    "replacement_price" => 32000,
-                    "is_hidden_on_bill" => false,
-                    "is_discountable" => false,
-                    "picture" => null,
-                    "note" => null,
-                    "created_at" => null,
-                    "updated_at" => null,
-                    "deleted_at" => null,
-                    "tags" => [
-                    ],
-                    "attributes" => [
-                    ],
-                    "events" => [
-                    ]
+                    'id' => 7,
+                    'name' => 'Volkswagen Transporter',
+                    'description' => 'Volume utile : 9.3 m3',
+                    'reference' => 'Transporter',
+                    'is_unitary' => false,
+                    'park_id' => 1,
+                    'category_id' => 3,
+                    'sub_category_id' => null,
+                    'rental_price' => 300,
+                    'stock_quantity' => 0,
+                    'out_of_order_quantity' => 0,
+                    'replacement_price' => 32000,
+                    'is_hidden_on_bill' => false,
+                    'is_discountable' => false,
+                    'picture' => null,
+                    'note' => null,
+                    'created_at' => null,
+                    'updated_at' => null,
+                    'deleted_at' => null,
+                    'tags' => [],
+                    'attributes' => [],
+                    'events' => []
                 ]
             ]
         ]);


### PR DESCRIPTION
Voici ma proposition pour apporter plus de détails au retour des méthodes `getAll`. 
Comme vous pouvez le remarquer, j'ai modifié deux contrôleurs, car pour notre projet nous avons besoin de ces informations. Ce qui nous permettra en une seule requête avec un paramètre passé à "true" de récupérer tous les événements avec leurs matériels associés, ou tous les matériels avec leurs événements associés.

Si cela ne vous convient pas, je peux bien évidemment modifier le code pour convenir à vos attentes. 
